### PR TITLE
103902 - Refactoring: Impl IIsProjectQuery

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/IIsPunchItemCommand.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/IIsPunchItemCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using MediatR;
 
-namespace Equinor.ProCoSys.Completion.Command;
+namespace Equinor.ProCoSys.Completion.Command.PunchItemCommands;
 
 public interface IIsPunchItemCommand : IBaseRequest
 {

--- a/src/Equinor.ProCoSys.Completion.Query/Equinor.ProCoSys.Completion.Query.csproj
+++ b/src/Equinor.ProCoSys.Completion.Query/Equinor.ProCoSys.Completion.Query.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Equinor.ProCoSys.Completion.Command\Equinor.ProCoSys.Completion.Command.csproj" />
     <ProjectReference Include="..\Equinor.ProCoSys.Completion.Domain\Equinor.ProCoSys.Completion.Domain.csproj" />
     <ProjectReference Include="..\Equinor.ProCoSys.Completion.Infrastructure\Equinor.ProCoSys.Completion.Infrastructure.csproj" />
   </ItemGroup>

--- a/src/Equinor.ProCoSys.Completion.Query/IIsProjectQuery.cs
+++ b/src/Equinor.ProCoSys.Completion.Query/IIsProjectQuery.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using MediatR;
+
+namespace Equinor.ProCoSys.Completion.Query;
+
+public interface IIsProjectQuery : IBaseRequest
+{
+    Guid ProjectGuid { get; }
+}

--- a/src/Equinor.ProCoSys.Completion.Query/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQuery.cs
+++ b/src/Equinor.ProCoSys.Completion.Query/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQuery.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using Equinor.ProCoSys.Completion.Command;
 using MediatR;
 using ServiceResult;
 
 namespace Equinor.ProCoSys.Completion.Query.PunchItemQueries.GetPunchItemsInProject;
 
-public class GetPunchItemsInProjectQuery : IRequest<Result<IEnumerable<PunchItemDto>>>, IIsProjectCommand
+public class GetPunchItemsInProjectQuery : IRequest<Result<IEnumerable<PunchItemDto>>>, IIsProjectQuery
 {
     public GetPunchItemsInProjectQuery(Guid projectGuid) => ProjectGuid = projectGuid;
 

--- a/src/Equinor.ProCoSys.Completion.WebApi/Authorizations/AccessValidator.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Authorizations/AccessValidator.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command;
+using Equinor.ProCoSys.Completion.Command.PunchItemCommands;
 using Equinor.ProCoSys.Completion.Query.PunchItemQueries;
 using Equinor.ProCoSys.Completion.WebApi.Misc;
 using MediatR;

--- a/src/Equinor.ProCoSys.Completion.WebApi/Authorizations/AccessValidator.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Authorizations/AccessValidator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands;
+using Equinor.ProCoSys.Completion.Query;
 using Equinor.ProCoSys.Completion.Query.PunchItemQueries;
 using Equinor.ProCoSys.Completion.WebApi.Misc;
 using MediatR;
@@ -42,11 +43,24 @@ public class AccessValidator : IAccessValidator
         }
 
         var userOid = _currentUserProvider.GetCurrentUserOid();
-        if (request is IIsProjectCommand projectCommand &&
-            !_projectAccessChecker.HasCurrentUserAccessToProject(projectCommand.ProjectGuid))
+        if (request is IIsProjectCommand projectCommand)
         {
-            _logger.LogWarning("Current user {UserOid} don't have access to project {ProjectCommandProjectGuid}", userOid, projectCommand.ProjectGuid);
-            return false;
+            if (!_projectAccessChecker.HasCurrentUserAccessToProject(projectCommand.ProjectGuid))
+            {
+                _logger.LogWarning("Current user {UserOid} don't have access to project {ProjectCommandProjectGuid}",
+                    userOid, projectCommand.ProjectGuid);
+                return false;
+            }
+        }
+
+        if (request is IIsProjectQuery projectQuery)
+        {
+            if (!_projectAccessChecker.HasCurrentUserAccessToProject(projectQuery.ProjectGuid))
+            {
+                _logger.LogWarning("Current user {UserOid} don't have access to project {ProjectCommandProjectGuid}",
+                    userOid, projectQuery.ProjectGuid);
+                return false;
+            }
         }
 
         if (request is IIsPunchItemCommand punchItemCommand)

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/AccessValidatorTestCoverageTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/AccessValidatorTestCoverageTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Equinor.ProCoSys.Completion.Command;
+using Equinor.ProCoSys.Completion.Command.PunchItemCommands;
 using Equinor.ProCoSys.Completion.Query.PunchItemQueries;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectCommandTests;

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForCreatePunchCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForCreatePunchCommandTests.cs
@@ -6,9 +6,9 @@ namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectComma
 [TestClass]
 public class AccessValidatorForCreatePunchItemCommandTests : AccessValidatorForIIsProjectCommandTests<CreatePunchItemCommand>
 {
-    protected override CreatePunchItemCommand GetProjectRequestWithAccessToProjectToTest()
+    protected override CreatePunchItemCommand GetProjectCommandWithAccessToProjectToTest()
         => new(null!, ProjectGuidWithAccess);
 
-    protected override CreatePunchItemCommand GetProjectRequestWithoutAccessToProjectToTest()
+    protected override CreatePunchItemCommand GetProjectCommandWithoutAccessToProjectToTest()
         => new(null!, ProjectGuidWithoutAccess);
 }

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForIIsProjectCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForIIsProjectCommandTests.cs
@@ -6,17 +6,17 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectCommandTests;
 
 [TestClass]
-public abstract class AccessValidatorForIIsProjectCommandTests<TProjectRequest> : AccessValidatorTestBase
-    where TProjectRequest : IBaseRequest, IIsProjectCommand
+public abstract class AccessValidatorForIIsProjectCommandTests<TProjectCommand> : AccessValidatorTestBase
+    where TProjectCommand : IBaseRequest, IIsProjectCommand
 {
-    protected abstract TProjectRequest GetProjectRequestWithAccessToProjectToTest();
-    protected abstract TProjectRequest GetProjectRequestWithoutAccessToProjectToTest();
+    protected abstract TProjectCommand GetProjectCommandWithAccessToProjectToTest();
+    protected abstract TProjectCommand GetProjectCommandWithoutAccessToProjectToTest();
 
     [TestMethod]
     public async Task Validate_ShouldReturnTrue_WhenAccessToProject()
     {
         // Arrange
-        var command = GetProjectRequestWithAccessToProjectToTest();
+        var command = GetProjectCommandWithAccessToProjectToTest();
 
         // act
         var result = await _dut.ValidateAsync(command);
@@ -29,7 +29,7 @@ public abstract class AccessValidatorForIIsProjectCommandTests<TProjectRequest> 
     public async Task Validate_ShouldReturnFalse_WhenNoAccessToProject()
     {
         // Arrange
-        var command = GetProjectRequestWithoutAccessToProjectToTest();
+        var command = GetProjectCommandWithoutAccessToProjectToTest();
 
         // act
         var result = await _dut.ValidateAsync(command);

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForGetPunchItemsInProjectQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForGetPunchItemsInProjectQueryTests.cs
@@ -6,9 +6,9 @@ namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectQuery
 [TestClass]
 public class AccessValidatorForGetPunchItemsInProjectQueryTests : AccessValidatorForIIsProjectQueryTests<GetPunchItemsInProjectQuery>
 {
-    protected override GetPunchItemsInProjectQuery GetProjectRequestWithAccessToProjectToTest()
+    protected override GetPunchItemsInProjectQuery GetProjectQueryWithAccessToProjectToTest()
         => new(ProjectGuidWithAccess);
 
-    protected override GetPunchItemsInProjectQuery GetProjectRequestWithoutAccessToProjectToTest()
+    protected override GetPunchItemsInProjectQuery GetProjectQueryWithoutAccessToProjectToTest()
         => new(ProjectGuidWithoutAccess);
 }

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForGetPunchItemsInProjectQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForGetPunchItemsInProjectQueryTests.cs
@@ -1,0 +1,14 @@
+﻿using Equinor.ProCoSys.Completion.Query.PunchItemQueries.GetPunchItemsInProject;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectQueryTests;
+
+[TestClass]
+public class AccessValidatorForGetPunchItemsInProjectQueryTests : AccessValidatorForIIsProjectQueryTests<GetPunchItemsInProjectQuery>
+{
+    protected override GetPunchItemsInProjectQuery GetProjectRequestWithAccessToProjectToTest()
+        => new(ProjectGuidWithAccess);
+
+    protected override GetPunchItemsInProjectQuery GetProjectRequestWithoutAccessToProjectToTest()
+        => new(ProjectGuidWithoutAccess);
+}

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForIIsProjectQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForIIsProjectQueryTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Equinor.ProCoSys.Completion.Query;
+using MediatR;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectQueryTests;
+
+[TestClass]
+public abstract class AccessValidatorForIIsProjectQueryTests<TProjectQuery> : AccessValidatorTestBase
+    where TProjectQuery : IBaseRequest, IIsProjectQuery
+{
+    protected abstract TProjectQuery GetProjectRequestWithAccessToProjectToTest();
+    protected abstract TProjectQuery GetProjectRequestWithoutAccessToProjectToTest();
+
+    [TestMethod]
+    public async Task Validate_ShouldReturnTrue_WhenAccessToProject()
+    {
+        // Arrange
+        var query = GetProjectRequestWithAccessToProjectToTest();
+
+        // act
+        var result = await _dut.ValidateAsync(query);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task Validate_ShouldReturnFalse_WhenNoAccessToProject()
+    {
+        // Arrange
+        var query = GetProjectRequestWithoutAccessToProjectToTest();
+
+        // act
+        var result = await _dut.ValidateAsync(query);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForIIsProjectQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectQueryTests/AccessValidatorForIIsProjectQueryTests.cs
@@ -9,14 +9,14 @@ namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectQuery
 public abstract class AccessValidatorForIIsProjectQueryTests<TProjectQuery> : AccessValidatorTestBase
     where TProjectQuery : IBaseRequest, IIsProjectQuery
 {
-    protected abstract TProjectQuery GetProjectRequestWithAccessToProjectToTest();
-    protected abstract TProjectQuery GetProjectRequestWithoutAccessToProjectToTest();
+    protected abstract TProjectQuery GetProjectQueryWithAccessToProjectToTest();
+    protected abstract TProjectQuery GetProjectQueryWithoutAccessToProjectToTest();
 
     [TestMethod]
     public async Task Validate_ShouldReturnTrue_WhenAccessToProject()
     {
         // Arrange
-        var query = GetProjectRequestWithAccessToProjectToTest();
+        var query = GetProjectQueryWithAccessToProjectToTest();
 
         // act
         var result = await _dut.ValidateAsync(query);
@@ -29,7 +29,7 @@ public abstract class AccessValidatorForIIsProjectQueryTests<TProjectQuery> : Ac
     public async Task Validate_ShouldReturnFalse_WhenNoAccessToProject()
     {
         // Arrange
-        var query = GetProjectRequestWithoutAccessToProjectToTest();
+        var query = GetProjectQueryWithoutAccessToProjectToTest();
 
         // act
         var result = await _dut.ValidateAsync(query);

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsPunchItemCommandTests/AccessValidatorForIIsPunchItemCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsPunchItemCommandTests/AccessValidatorForIIsPunchItemCommandTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using Equinor.ProCoSys.Completion.Command;
+using Equinor.ProCoSys.Completion.Command.PunchItemCommands;
 using MediatR;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsPunchItemQueryTests/AccessValidatorForIIsPunchItemQueryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsPunchItemQueryTests/AccessValidatorForIIsPunchItemQueryTests.cs
@@ -16,10 +16,10 @@ public abstract class AccessValidatorForIIsPunchItemQueryTests<TPunchItemQuery> 
     public async Task Validate_ShouldReturnTrue_WhenAccessToProjectForPunchItem()
     {
         // Arrange
-        var command = GetPunchItemQueryWithAccessToProject();
+        var query = GetPunchItemQueryWithAccessToProject();
 
         // act
-        var result = await _dut.ValidateAsync(command);
+        var result = await _dut.ValidateAsync(query);
 
         // Assert
         Assert.IsTrue(result);
@@ -29,10 +29,10 @@ public abstract class AccessValidatorForIIsPunchItemQueryTests<TPunchItemQuery> 
     public async Task Validate_ShouldReturnFalse_WhenNoAccessToProjectForPunchItem()
     {
         // Arrange
-        var command = GetPunchItemQueryWithoutAccessToProject();
+        var query = GetPunchItemQueryWithoutAccessToProject();
 
         // act
-        var result = await _dut.ValidateAsync(command);
+        var result = await _dut.ValidateAsync(query);
 
         // Assert
         Assert.IsFalse(result);


### PR DESCRIPTION
Found a minor design "error" when working with Library. The Query project had reference the Command project 
GetPunchItemsInProjectQuery implement the IIsProjectCommand interface from Command project. 
Should be IIsProjectQuery interface in Query project

Connect to first PBI: [AB#103902](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/103902)