### PR TITLE
103915 library entity vol3

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommand.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommand.cs
@@ -6,12 +6,20 @@ namespace Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
 
 public class CreatePunchItemCommand : IRequest<Result<GuidAndRowVersion>>, IIsProjectCommand
 {
-    public CreatePunchItemCommand(string description, Guid projectGuid)
+    public CreatePunchItemCommand(
+        string description,
+        Guid projectGuid,
+        Guid raisedByOrgGuid,
+        Guid clearingByOrgGuid)
     {
         Description = description;
         ProjectGuid = projectGuid;
+        RaisedByOrgGuid = raisedByOrgGuid;
+        ClearingByOrgGuid = clearingByOrgGuid;
     }
 
     public string Description { get; }
     public Guid ProjectGuid { get; }
+    public Guid RaisedByOrgGuid { get; }
+    public Guid ClearingByOrgGuid { get; }
 }

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -8,6 +8,7 @@ using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using MediatR;
 using ServiceResult;
 using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
@@ -18,18 +19,21 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
 
     private readonly IPlantProvider _plantProvider;
     private readonly IPunchItemRepository _punchItemRepository;
+    private readonly ILibraryItemRepository _libraryItemRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IProjectRepository _projectRepository;
 
     public CreatePunchItemCommandHandler(
         IPlantProvider plantProvider,
         IPunchItemRepository punchItemRepository,
+        ILibraryItemRepository libraryItemRepository,
         IUnitOfWork unitOfWork,
         IProjectRepository projectRepository,
         ILogger<CreatePunchItemCommandHandler> logger)
     {
         _plantProvider = plantProvider;
         _punchItemRepository = punchItemRepository;
+        _libraryItemRepository = libraryItemRepository;
         _unitOfWork = unitOfWork;
         _projectRepository = projectRepository;
         _logger = logger;
@@ -40,10 +44,13 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         var project = await _projectRepository.GetByGuidAsync(request.ProjectGuid);
         if (project is null)
         {
-            throw new Exception($"Could not find ProCoSys project with Guid {request.ProjectGuid} in plant {_plantProvider.Plant}");
+            throw new Exception($"Could not find {nameof(Project)} with Guid {request.ProjectGuid} in plant {_plantProvider.Plant}");
         }
 
-        var punchItem = new PunchItem(_plantProvider.Plant, project, request.Description);
+        var raisedByOrg = await GetLibraryItem(request.RaisedByOrgGuid, LibraryTypes.COMPLETION_ORGANIZATION);
+        var clearingByOrg = await GetLibraryItem(request.ClearingByOrgGuid, LibraryTypes.COMPLETION_ORGANIZATION);
+
+        var punchItem = new PunchItem(_plantProvider.Plant, project, request.Description, raisedByOrg, clearingByOrg);
         _punchItemRepository.Add(punchItem);
         punchItem.AddDomainEvent(new PunchItemCreatedDomainEvent(punchItem, request.ProjectGuid));
 
@@ -52,5 +59,17 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         _logger.LogInformation("Punch item '{PunchItemNo}' with guid {PunchItemGuid} created", punchItem.ItemNo, punchItem.Guid);
 
         return new SuccessResult<GuidAndRowVersion>(new GuidAndRowVersion(punchItem.Guid, punchItem.RowVersion.ConvertToString()));
+    }
+
+    private async Task<LibraryItem> GetLibraryItem(Guid libraryGuid, LibraryTypes type)
+    {
+        var libraryItem = await _libraryItemRepository.GetByGuidAndTypeAsync(libraryGuid, type);
+        if (libraryItem is null)
+        {
+            throw new Exception(
+                $"Could not find {nameof(LibraryItem)} of type {type} with Guid {libraryGuid} in plant {_plantProvider.Plant}");
+        }
+
+        return libraryItem;
     }
 }

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/LibraryAggregate/ILibraryItemRepository.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/LibraryAggregate/ILibraryItemRepository.cs
@@ -1,5 +1,9 @@
-﻿namespace Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 
 public interface ILibraryItemRepository : IRepositoryWithGuid<LibraryItem>
 {
+    Task<LibraryItem?> GetByGuidAndTypeAsync(Guid libraryGuid, LibraryTypes type);
 }

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
@@ -4,6 +4,7 @@ using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Audit;
 using Equinor.ProCoSys.Common.Time;
 using Equinor.ProCoSys.Common;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 
 namespace Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 
@@ -19,19 +20,29 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
     {
     }
 
-    public PunchItem(string plant, Project project, string description)
+    public PunchItem(
+        string plant,
+        Project project,
+        string description,
+        LibraryItem raisedByOrg,
+        LibraryItem clearingByOrg)
         : base(plant)
     {
-        if (project is null)
-        {
-            throw new ArgumentNullException(nameof(project));
-        }
-
         if (project.Plant != plant)
         {
             throw new ArgumentException($"Can't relate item in {project.Plant} to item in {plant}");
         }
+        if (raisedByOrg.Plant != plant)
+        {
+            throw new ArgumentException($"Can't relate item in {raisedByOrg.Plant} to item in {plant}");
+        }
+        if (clearingByOrg.Plant != plant)
+        {
+            throw new ArgumentException($"Can't relate item in {clearingByOrg.Plant} to item in {plant}");
+        }
         ProjectId = project.Id;
+        RaisedByOrgId = raisedByOrg.Id;
+        ClearingByOrgId = clearingByOrg.Id;
         Description = description;
         Guid = Guid.NewGuid();
     }
@@ -40,6 +51,11 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
     public int ProjectId { get; private set; }
     public int ItemNo => Id;
     public string Description { get; set; }
+    public int RaisedByOrgId { get; private set; }
+    public int ClearingByOrgId { get; private set; }
+    public int? SortingId { get; private set; }
+    public int? TypeId { get; private set; }
+    public int? PriorityId { get; private set; }
 
     public DateTime CreatedAtUtc { get; private set; }
     public int CreatedById { get; private set; }
@@ -129,5 +145,35 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
         ModifiedAtUtc = TimeService.UtcNow;
         ModifiedById = modifiedBy.Id;
         ModifiedByOid = modifiedBy.Guid;
+    }
+
+    public void SetSortingId(LibraryItem sorting)
+    {
+        if (sorting.Plant != Plant)
+        {
+            throw new ArgumentException($"Can't relate item in {sorting.Plant} to item in {Plant}");
+        }
+
+        SortingId = sorting.Id;
+    }
+
+    public void SetTypeId(LibraryItem type)
+    {
+        if (type.Plant != Plant)
+        {
+            throw new ArgumentException($"Can't relate item in {type.Plant} to item in {Plant}");
+        }
+
+        TypeId = type.Id;
+    }
+
+    public void SetPriorityId(LibraryItem priority)
+    {
+        if (priority.Plant != Plant)
+        {
+            throw new ArgumentException($"Can't relate item in {priority.Plant} to item in {Plant}");
+        }
+
+        PriorityId = priority.Id;
     }
 }

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
+﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure.EntityConfigurations.Extensions;
@@ -61,6 +62,36 @@ internal class PunchItemConfiguration : IEntityTypeConfiguration<PunchItem>
             .HasForeignKey(x => x.VerifiedById)
             .OnDelete(DeleteBehavior.NoAction);
 
+        builder
+            .HasOne<LibraryItem>()
+            .WithMany()
+            .HasForeignKey(x => x.RaisedByOrgId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder
+            .HasOne<LibraryItem>()
+            .WithMany()
+            .HasForeignKey(x => x.ClearingByOrgId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder
+            .HasOne<LibraryItem>()
+            .WithMany()
+            .HasForeignKey(x => x.SortingId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder
+            .HasOne<LibraryItem>()
+            .WithMany()
+            .HasForeignKey(x => x.TypeId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder
+            .HasOne<LibraryItem>()
+            .WithMany()
+            .HasForeignKey(x => x.PriorityId)
+            .OnDelete(DeleteBehavior.NoAction);
+
         // both ClearedAtUtc and ClearedById fields must either be set or not set
         builder
             .ToTable(x => x.HasCheckConstraint("punch_item_check_cleared",
@@ -107,6 +138,11 @@ internal class PunchItemConfiguration : IEntityTypeConfiguration<PunchItem>
                 x.VerifiedAtUtc,
                 x.RejectedById,
                 x.RejectedAtUtc,
+                x.RaisedByOrgId,
+                x.ClearingByOrgId,
+                x.SortingId,
+                x.TypeId,
+                x.PriorityId,
                 x.RowVersion
             });
 

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230803062141_PunchItemLibraryRefs.Designer.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230803062141_PunchItemLibraryRefs.Designer.cs
@@ -4,6 +4,7 @@ using Equinor.ProCoSys.Completion.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Equinor.ProCoSys.Completion.Infrastructure.Migrations
 {
     [DbContext(typeof(CompletionContext))]
-    partial class CompletionContextModelSnapshot : ModelSnapshot
+    [Migration("20230803062141_PunchItemLibraryRefs")]
+    partial class PunchItemLibraryRefs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230803062141_PunchItemLibraryRefs.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230803062141_PunchItemLibraryRefs.cs
@@ -1,0 +1,240 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equinor.ProCoSys.Completion.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class PunchItemLibraryRefs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_Guid",
+                table: "PunchItems");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClearingByOrgId",
+                table: "PunchItems",
+                type: "int",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PriorityId",
+                table: "PunchItems",
+                type: "int",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<int>(
+                name: "RaisedByOrgId",
+                table: "PunchItems",
+                type: "int",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SortingId",
+                table: "PunchItems",
+                type: "int",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TypeId",
+                table: "PunchItems",
+                type: "int",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_ClearingByOrgId",
+                table: "PunchItems",
+                column: "ClearingByOrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_Guid",
+                table: "PunchItems",
+                column: "Guid")
+                .Annotation("SqlServer:Include", new[] { "Id", "Description", "ProjectId", "CreatedById", "CreatedAtUtc", "ModifiedById", "ModifiedAtUtc", "ClearedById", "ClearedAtUtc", "VerifiedById", "VerifiedAtUtc", "RejectedById", "RejectedAtUtc", "RaisedByOrgId", "ClearingByOrgId", "SortingId", "TypeId", "PriorityId", "RowVersion" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_PriorityId",
+                table: "PunchItems",
+                column: "PriorityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_RaisedByOrgId",
+                table: "PunchItems",
+                column: "RaisedByOrgId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_SortingId",
+                table: "PunchItems",
+                column: "SortingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_TypeId",
+                table: "PunchItems",
+                column: "TypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PunchItems_Library_ClearingByOrgId",
+                table: "PunchItems",
+                column: "ClearingByOrgId",
+                principalTable: "Library",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PunchItems_Library_PriorityId",
+                table: "PunchItems",
+                column: "PriorityId",
+                principalTable: "Library",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PunchItems_Library_RaisedByOrgId",
+                table: "PunchItems",
+                column: "RaisedByOrgId",
+                principalTable: "Library",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PunchItems_Library_SortingId",
+                table: "PunchItems",
+                column: "SortingId",
+                principalTable: "Library",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PunchItems_Library_TypeId",
+                table: "PunchItems",
+                column: "TypeId",
+                principalTable: "Library",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PunchItems_Library_ClearingByOrgId",
+                table: "PunchItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PunchItems_Library_PriorityId",
+                table: "PunchItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PunchItems_Library_RaisedByOrgId",
+                table: "PunchItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PunchItems_Library_SortingId",
+                table: "PunchItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PunchItems_Library_TypeId",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_ClearingByOrgId",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_Guid",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_PriorityId",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_RaisedByOrgId",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_SortingId",
+                table: "PunchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PunchItems_TypeId",
+                table: "PunchItems");
+
+            migrationBuilder.DropColumn(
+                name: "ClearingByOrgId",
+                table: "PunchItems")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.DropColumn(
+                name: "PriorityId",
+                table: "PunchItems")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.DropColumn(
+                name: "RaisedByOrgId",
+                table: "PunchItems")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.DropColumn(
+                name: "SortingId",
+                table: "PunchItems")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.DropColumn(
+                name: "TypeId",
+                table: "PunchItems")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "PunchItemsHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", null)
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PunchItems_Guid",
+                table: "PunchItems",
+                column: "Guid")
+                .Annotation("SqlServer:Include", new[] { "Id", "Description", "ProjectId", "CreatedById", "CreatedAtUtc", "ModifiedById", "ModifiedAtUtc", "ClearedById", "ClearedAtUtc", "VerifiedById", "VerifiedAtUtc", "RejectedById", "RejectedAtUtc", "RowVersion" });
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Repositories/LibraryItemRepository.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Repositories/LibraryItemRepository.cs
@@ -1,4 +1,7 @@
-﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+﻿using System;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equinor.ProCoSys.Completion.Infrastructure.Repositories;
 
@@ -8,4 +11,8 @@ public class LibraryItemRepository : EntityWithGuidRepository<LibraryItem>, ILib
         : base(context, context.Library)
     {
     }
+
+    public Task<LibraryItem?> GetByGuidAndTypeAsync(Guid libraryGuid, LibraryTypes type)
+        => DefaultQuery.SingleOrDefaultAsync(x => x.Guid == libraryGuid && x.Type == type.ToString());
+
 }

--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/CreatePunchItemDto.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/CreatePunchItemDto.cs
@@ -7,4 +7,8 @@ public record CreatePunchItemDto(
     [Required]
     string Description, 
     [Required]
-    Guid ProjectGuid);
+    Guid ProjectGuid,
+    [Required]
+    Guid RaisedByOrgGuid,
+    [Required]
+    Guid ClearingByOrgGuid);

--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
@@ -86,7 +86,11 @@ public class PunchItemsController : ControllerBase
         [FromBody] CreatePunchItemDto dto)
     {
         
-        var result = await _mediator.Send(new CreatePunchItemCommand(dto.Description, dto.ProjectGuid));
+        var result = await _mediator.Send(new CreatePunchItemCommand(
+            dto.Description,
+            dto.ProjectGuid,
+            dto.RaisedByOrgGuid, 
+            dto.ClearingByOrgGuid));
         return this.FromResult(result);
     }
 

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/EventHandlerTestBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/EventHandlerTestBase.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,7 +14,8 @@ public class EventHandlerTestBase
 {
     protected DateTime _now = new(2021, 1, 1, 12, 0, 0, DateTimeKind.Utc);
     protected Person _person;
-
+    protected PunchItem _punchItem;
+    protected Project _project;
 
     [TestInitialize]
     public void SetupBase()
@@ -19,5 +23,11 @@ public class EventHandlerTestBase
         TimeService.SetProvider(new ManualTimeProvider(_now));
         _person = new Person(Guid.NewGuid(), null!, null!, null!, null!);
         _person.SetProtectedIdForTesting(3);
+
+        var testPlant = "X";
+        _project = new Project(testPlant, Guid.NewGuid(), null!, null!);
+        var raisedByOrg = new LibraryItem(testPlant, Guid.NewGuid(), null!, null!, null!);
+        var clearingByOrg = new LibraryItem(testPlant, Guid.NewGuid(), null!, null!, null!);
+        _punchItem = new PunchItem(testPlant, _project, null!, raisedByOrg, clearingByOrg);
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemClearedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemClearedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,11 +21,10 @@ public class PunchItemClearedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var punchItem = new PunchItem("X", new Project("X", Guid.NewGuid(), "Pro", "Desc"), "F");
-        punchItem.Clear(_person);
-        punchItem.SetModified(_person);
+        _punchItem.Clear(_person);
+        _punchItem.SetModified(_person);
 
-        _punchItemClearedEvent = new PunchItemClearedDomainEvent(punchItem, _person.Guid);
+        _punchItemClearedEvent = new PunchItemClearedDomainEvent(_punchItem, _person.Guid);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemClearedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemClearedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemCreatedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemCreatedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,11 +21,9 @@ public class PunchItemCreatedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var projectGuid = Guid.NewGuid();
-        var punchItem = new PunchItem("X", new Project("X", projectGuid, "Pro", "Desc"), "F");
-        punchItem.SetCreated(_person);
+        _punchItem.SetCreated(_person);
 
-        _punchItemCreatedEvent = new PunchItemCreatedDomainEvent(punchItem, projectGuid);
+        _punchItemCreatedEvent = new PunchItemCreatedDomainEvent(_punchItem, _project.Guid);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemCreatedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemCreatedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemRejectedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemRejectedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,12 +21,11 @@ public class PunchItemRejectedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var punchItem = new PunchItem("X", new Project("X", Guid.NewGuid(), "Pro", "Desc"), "F");
-        punchItem.Clear(_person);
-        punchItem.Reject(_person);
-        punchItem.SetModified(_person);
+        _punchItem.Clear(_person);
+        _punchItem.Reject(_person);
+        _punchItem.SetModified(_person);
 
-        _punchItemRejectedEvent = new PunchItemRejectedDomainEvent(punchItem, _person.Guid);
+        _punchItemRejectedEvent = new PunchItemRejectedDomainEvent(_punchItem, _person.Guid);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemRejectedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemRejectedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemUnclearedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemUnclearedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,12 +21,11 @@ public class PunchItemUnclearedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var punchItem = new PunchItem("X", new Project("X", Guid.NewGuid(), "Pro", "Desc"), "F");
-        punchItem.Clear(_person);
-        punchItem.Unclear();
-        punchItem.SetModified(_person);
+        _punchItem.Clear(_person);
+        _punchItem.Unclear();
+        _punchItem.SetModified(_person);
 
-        _punchItemUnclearedEvent = new PunchItemUnclearedDomainEvent(punchItem);
+        _punchItemUnclearedEvent = new PunchItemUnclearedDomainEvent(_punchItem);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemUnclearedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemUnclearedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemUnverifiedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemUnverifiedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,12 +21,11 @@ public class PunchItemUnverifiedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var punchItem = new PunchItem("X", new Project("X", Guid.NewGuid(), "Pro", "Desc"), "F");
-        punchItem.Clear(_person);
-        punchItem.Verify(_person);
-        punchItem.SetModified(_person);
+        _punchItem.Clear(_person);
+        _punchItem.Verify(_person);
+        _punchItem.SetModified(_person);
 
-        _punchItemUnverifiedEvent = new PunchItemUnverifiedDomainEvent(punchItem);
+        _punchItemUnverifiedEvent = new PunchItemUnverifiedDomainEvent(_punchItem);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemUnverifiedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemUnverifiedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemVerifiedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemVerifiedEventHandlerTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Threading;
-using Microsoft.Extensions.Logging;
-using Equinor.ProCoSys.Completion.Command.EventHandlers.DomainEvents.PunchItemEvents.IntegrationEvents;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.EventHandlers.DomainEvents.PunchItemEvents;
 
@@ -24,12 +21,11 @@ public class PunchItemVerifiedEventHandlerTests : EventHandlerTestBase
     [TestInitialize]
     public void Setup()
     {
-        var punchItem = new PunchItem("X", new Project("X", Guid.NewGuid(), "Pro", "Desc"), "F");
-        punchItem.Clear(_person);
-        punchItem.Verify(_person);
-        punchItem.SetModified(_person);
+        _punchItem.Clear(_person);
+        _punchItem.Verify(_person);
+        _punchItem.SetModified(_person);
 
-        _punchItemVerifiedEvent = new PunchItemVerifiedDomainEvent(punchItem, _person.Guid);
+        _punchItemVerifiedEvent = new PunchItemVerifiedDomainEvent(_punchItem, _person.Guid);
         _publishEndpointMock = new Mock<IPublishEndpoint>();
         _dut = new PunchItemVerifiedEventHandler(_publishEndpointMock.Object, new Mock<ILogger<PunchItemVerifiedEventHandler>>().Object);
         _publishEndpointMock

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/ClearPunchItem/ClearPunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/ClearPunchItem/ClearPunchItemCommandHandlerTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.ClearPunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
-using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,37 +10,19 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.ClearPunchItem;
 
 [TestClass]
-public class ClearPunchItemCommandHandlerTests : TestsBase
+public class ClearPunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly int _currentPersonId = 13;
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private ClearPunchItemCommand _command;
     private ClearPunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var person = new Person(Guid.NewGuid(), "F", "L", "UN", "@");
-        person.SetProtectedIdForTesting(_currentPersonId);
-
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
-        var personRepositoryMock = new Mock<IPersonRepository>();
-
-        personRepositoryMock.Setup(r => r.GetCurrentPersonAsync())
-            .ReturnsAsync(person);
         _command = new ClearPunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 
         _dut = new ClearPunchItemCommandHandler(
             _punchItemRepositoryMock.Object,
-            personRepositoryMock.Object,
+            _personRepositoryMock.Object,
             _unitOfWorkMock.Object,
             new Mock<ILogger<ClearPunchItemCommandHandler>>().Object);
     }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
@@ -18,10 +19,15 @@ public class CreatePunchItemCommandHandlerTests : TestsBase
 {
     private Mock<IPunchItemRepository> _punchItemRepositoryMock;
     private Mock<IProjectRepository> _projectRepositoryMock;
+    private Mock<ILibraryItemRepository> _libraryItemRepositoryMock;
 
-    private readonly Guid _projectGuid = Guid.NewGuid();
     private readonly int _projectIdOnExisting = 10;
+    private readonly int _raisedByOrgIdOnExisting = 11;
+    private readonly int _clearingByOrgIdOnExisting = 12;
 
+    private Project _existingProject;
+    private LibraryItem _existingRaisedByOrg;
+    private LibraryItem _existingClearingByOrg;
     private PunchItem _punchItemAddedToRepository;
 
     private CreatePunchItemCommandHandler _dut;
@@ -37,18 +43,36 @@ public class CreatePunchItemCommandHandlerTests : TestsBase
             {
                 _punchItemAddedToRepository = punchItem;
             });
-        var project = new Project(TestPlantA, _projectGuid, null!, null!);
-        project.SetProtectedIdForTesting(_projectIdOnExisting);
+        _existingProject = new Project(TestPlantA, Guid.NewGuid(), null!, null!);
+        _existingProject.SetProtectedIdForTesting(_projectIdOnExisting);
         _projectRepositoryMock = new Mock<IProjectRepository>();
         _projectRepositoryMock
-            .Setup(x => x.GetByGuidAsync(_projectGuid))
-            .ReturnsAsync(project);
+            .Setup(x => x.GetByGuidAsync(_existingProject.Guid))
+            .ReturnsAsync(_existingProject);
 
-        _command = new CreatePunchItemCommand("P123", _projectGuid);
+        _existingRaisedByOrg = new LibraryItem(TestPlantA, Guid.NewGuid(), null!, null!, null!);
+        _existingRaisedByOrg.SetProtectedIdForTesting(_raisedByOrgIdOnExisting);
+        _existingClearingByOrg = new LibraryItem(TestPlantA, Guid.NewGuid(), null!, null!, null!);
+        _existingClearingByOrg.SetProtectedIdForTesting(_clearingByOrgIdOnExisting);
+
+        _libraryItemRepositoryMock = new Mock<ILibraryItemRepository>();
+        _libraryItemRepositoryMock
+            .Setup(x => x.GetByGuidAndTypeAsync(_existingRaisedByOrg.Guid, LibraryTypes.COMPLETION_ORGANIZATION))
+            .ReturnsAsync(_existingRaisedByOrg);
+        _libraryItemRepositoryMock
+            .Setup(x => x.GetByGuidAndTypeAsync(_existingClearingByOrg.Guid, LibraryTypes.COMPLETION_ORGANIZATION))
+            .ReturnsAsync(_existingClearingByOrg);
+
+        _command = new CreatePunchItemCommand(
+            "P123",
+            _existingProject.Guid,
+            _existingRaisedByOrg.Guid,
+            _existingClearingByOrg.Guid);
 
         _dut = new CreatePunchItemCommandHandler(
             _plantProviderMock.Object,
             _punchItemRepositoryMock.Object,
+            _libraryItemRepositoryMock.Object,
             _unitOfWorkMock.Object,
             _projectRepositoryMock.Object,
             new Mock<ILogger<CreatePunchItemCommandHandler>>().Object);
@@ -74,6 +98,8 @@ public class CreatePunchItemCommandHandlerTests : TestsBase
         Assert.IsNotNull(_punchItemAddedToRepository);
         Assert.AreEqual(_command.Description, _punchItemAddedToRepository.Description);
         Assert.AreEqual(_projectIdOnExisting, _punchItemAddedToRepository.ProjectId);
+        Assert.AreEqual(_raisedByOrgIdOnExisting, _punchItemAddedToRepository.RaisedByOrgId);
+        Assert.AreEqual(_clearingByOrgIdOnExisting, _punchItemAddedToRepository.ClearingByOrgId);
     }
 
     [TestMethod]
@@ -91,8 +117,32 @@ public class CreatePunchItemCommandHandlerTests : TestsBase
     {
         // Arrange
         _projectRepositoryMock
-            .Setup(x => x.GetByGuidAsync(_projectGuid))
+            .Setup(x => x.GetByGuidAsync(_existingProject.Guid))
             .ReturnsAsync((Project)null);
+
+        // Act and Assert
+        await Assert.ThrowsExceptionAsync<Exception>(() => _dut.Handle(_command, default));
+    }
+
+    [TestMethod]
+    public async Task HandlingCommand_ShouldThrewException_WhenRaisedByOrgNotExists()
+    {
+        // Arrange
+        _libraryItemRepositoryMock
+            .Setup(x => x.GetByGuidAndTypeAsync(_existingRaisedByOrg.Guid, LibraryTypes.COMPLETION_ORGANIZATION))
+            .ReturnsAsync((LibraryItem)null);
+
+        // Act and Assert
+        await Assert.ThrowsExceptionAsync<Exception>(() => _dut.Handle(_command, default));
+    }
+
+    [TestMethod]
+    public async Task HandlingCommand_ShouldThrewException_WhenClearingByOrgNotExists()
+    {
+        // Arrange
+        _libraryItemRepositoryMock
+            .Setup(x => x.GetByGuidAndTypeAsync(_existingClearingByOrg.Guid, LibraryTypes.COMPLETION_ORGANIZATION))
+            .ReturnsAsync((LibraryItem)null);
 
         // Act and Assert
         await Assert.ThrowsExceptionAsync<Exception>(() => _dut.Handle(_command, default));

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandValidatorTests.cs
@@ -17,7 +17,7 @@ public class CreatePunchItemCommandValidatorTests
     [TestInitialize]
     public void Setup_OkState()
     {
-        _command = new CreatePunchItemCommand("Test title", Guid.NewGuid());
+        _command = new CreatePunchItemCommand("Test title", Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
         _projectValidatorMock = new Mock<IProjectValidator>();
         _projectValidatorMock.Setup(x => x.ExistsAsync(_command.ProjectGuid, default))
             .ReturnsAsync(true);

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandlerTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.DeletePunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -14,25 +10,14 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.DeletePunchItem;
 
 [TestClass]
-public class DeletePunchItemCommandHandlerTests : TestsBase
+public class DeletePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private DeletePunchItemCommand _command;
     private DeletePunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "P123");
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
-
         _command = new DeletePunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 
         _dut = new DeletePunchItemCommandHandler(

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/PunchItemCommandHandlerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/PunchItemCommandHandlerTestsBase.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+using Equinor.ProCoSys.Completion.Test.Common;
+using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands;
+
+public class PunchItemCommandHandlerTestsBase : TestsBase
+{
+    protected int _currentPersonId = 13;
+    protected string _rowVersion = "AAAAAAAAABA=";
+    protected Mock<IPersonRepository> _personRepositoryMock;
+    protected Mock<IPunchItemRepository> _punchItemRepositoryMock;
+    protected PunchItem _existingPunchItem;
+    protected Person _currentPerson;
+
+    [TestInitialize]
+    public void PunchItemCommandHandlerTestsBaseSetup()
+    {
+        var project = new Project(TestPlantA, Guid.NewGuid(), null!, null!);
+        var raisedByOrg = new LibraryItem(TestPlantA, Guid.NewGuid(), null!, null!, null!);
+        var clearingByOrg = new LibraryItem(TestPlantA, Guid.NewGuid(), null!, null!, null!);
+        _existingPunchItem = new PunchItem(TestPlantA, project, null!, raisedByOrg, clearingByOrg);
+
+        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
+        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
+            .ReturnsAsync(_existingPunchItem);
+
+        _currentPerson = new Person(Guid.NewGuid(), null!, null!, null!, null!);
+        _currentPerson.SetProtectedIdForTesting(_currentPersonId);
+
+        _personRepositoryMock = new Mock<IPersonRepository>();
+
+        _personRepositoryMock.Setup(r => r.GetCurrentPersonAsync())
+            .ReturnsAsync(_currentPerson);
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/RejectPunchItem/RejectPunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/RejectPunchItem/RejectPunchItemCommandHandlerTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.RejectPunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
-using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,38 +10,21 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.RejectPunchItem;
 
 [TestClass]
-public class RejectPunchItemCommandHandlerTests : TestsBase
+public class RejectPunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly int _currentPersonId = 13;
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private RejectPunchItemCommand _command;
     private RejectPunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var person = new Person(Guid.NewGuid(), "F", "L", "UN", "@");
-        person.SetProtectedIdForTesting(_currentPersonId);
+        _existingPunchItem.Clear(_currentPerson);
 
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _existingPunchItem.Clear(person);
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
-        var personRepositoryMock = new Mock<IPersonRepository>();
-
-        personRepositoryMock.Setup(r => r.GetCurrentPersonAsync())
-            .ReturnsAsync(person);
         _command = new RejectPunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 
         _dut = new RejectPunchItemCommandHandler(
             _punchItemRepositoryMock.Object,
-            personRepositoryMock.Object,
+            _personRepositoryMock.Object,
             _unitOfWorkMock.Object,
             new Mock<ILogger<RejectPunchItemCommandHandler>>().Object);
     }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UnclearPunchItem/UnclearPunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UnclearPunchItem/UnclearPunchItemCommandHandlerTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.UnclearPunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
-using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,29 +10,15 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.UnclearPunchItem;
 
 [TestClass]
-public class UnclearPunchItemCommandHandlerTests : TestsBase
+public class UnclearPunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly int _currentPersonId = 13;
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private UnclearPunchItemCommand _command;
     private UnclearPunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var person = new Person(Guid.NewGuid(), "F", "L", "UN", "@");
-        person.SetProtectedIdForTesting(_currentPersonId);
-
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _existingPunchItem.Clear(person);
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
+        _existingPunchItem.Clear(_currentPerson);
 
         _command = new UnclearPunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UnverifyPunchItem/UnverifyPunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UnverifyPunchItem/UnverifyPunchItemCommandHandlerTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.UnverifyPunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
-using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,30 +10,16 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.UnverifyPunchItem;
 
 [TestClass]
-public class UnverifyPunchItemCommandHandlerTests : TestsBase
+public class UnverifyPunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly int _currentPersonId = 13;
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private UnverifyPunchItemCommand _command;
     private UnverifyPunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var person = new Person(Guid.NewGuid(), "F", "L", "UN", "@");
-        person.SetProtectedIdForTesting(_currentPersonId);
-
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _existingPunchItem.Clear(person);
-        _existingPunchItem.Verify(person);
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
+        _existingPunchItem.Clear(_currentPerson);
+        _existingPunchItem.Verify(_currentPerson);
 
         _command = new UnverifyPunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.UpdatePunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -14,25 +10,14 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.UpdatePunchItem;
 
 [TestClass]
-public class UpdatePunchItemCommandHandlerTests : TestsBase
+public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private UpdatePunchItemCommand _command;
     private UpdatePunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
-
         _command = new UpdatePunchItemCommand(_existingPunchItem.Guid, "newText", _rowVersion);
 
         _dut = new UpdatePunchItemCommandHandler(

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/VerifyPunchItem/VerifyPunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/VerifyPunchItem/VerifyPunchItemCommandHandlerTests.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.VerifyPunchItem;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
-using Equinor.ProCoSys.Completion.Test.Common;
-using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,38 +10,21 @@ using Moq;
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.VerifyPunchItem;
 
 [TestClass]
-public class VerifyPunchItemCommandHandlerTests : TestsBase
+public class VerifyPunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBase
 {
-    private readonly int _currentPersonId = 13;
-    private readonly string _rowVersion = "AAAAAAAAABA=";
-
-    private Mock<IPunchItemRepository> _punchItemRepositoryMock;
-    private PunchItem _existingPunchItem;
-
     private VerifyPunchItemCommand _command;
     private VerifyPunchItemCommandHandler _dut;
 
     [TestInitialize]
     public void Setup()
     {
-        var person = new Person(Guid.NewGuid(), "F", "L", "UN", "@");
-        person.SetProtectedIdForTesting(_currentPersonId);
-
-        var project = new Project(TestPlantA, Guid.NewGuid(), "P", "D");
-        _existingPunchItem = new PunchItem(TestPlantA, project, "X1");
-        _existingPunchItem.Clear(person);
-        _punchItemRepositoryMock = new Mock<IPunchItemRepository>();
-        _punchItemRepositoryMock.Setup(r => r.GetByGuidAsync(_existingPunchItem.Guid))
-            .ReturnsAsync(_existingPunchItem);
-        var personRepositoryMock = new Mock<IPersonRepository>();
-
-        personRepositoryMock.Setup(r => r.GetCurrentPersonAsync())
-            .ReturnsAsync(person);
+        _existingPunchItem.Clear(_currentPerson);
+        
         _command = new VerifyPunchItemCommand(_existingPunchItem.Guid, _rowVersion);
 
         _dut = new VerifyPunchItemCommandHandler(
             _punchItemRepositoryMock.Object,
-            personRepositoryMock.Object,
+            _personRepositoryMock.Object,
             _unitOfWorkMock.Object,
             new Mock<ILogger<VerifyPunchItemCommandHandler>>().Object);
     }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Validators/PunchItemValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Validators/PunchItemValidatorTests.cs
@@ -22,12 +22,12 @@ public class PunchItemValidatorTests : ReadOnlyTestsBase
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
-        _punchItemInOpenProject = new PunchItem(TestPlantA, _projectA, "x1");
-        _punchItemInClosedProject = new PunchItem(TestPlantA, _closedProjectC, "x2");
+        _punchItemInOpenProject = new PunchItem(TestPlantA, _projectA, "x1", _raisedByOrg, _clearingByOrg);
+        _punchItemInClosedProject = new PunchItem(TestPlantA, _closedProjectC, "x2", _raisedByOrg, _clearingByOrg);
         _notClearedPunchItem = _punchItemInOpenProject;
-        _clearedButNotVerifiedPunchItem = new PunchItem(TestPlantA, _projectA, "x3");
+        _clearedButNotVerifiedPunchItem = new PunchItem(TestPlantA, _projectA, "x3", _raisedByOrg, _clearingByOrg);
         _clearedButNotVerifiedPunchItem.Clear(_currentPerson);
-        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, "x4");
+        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, "x4", _raisedByOrg, _clearingByOrg);
         _verifiedPunchItem.Clear(_currentPerson);
         _verifiedPunchItem.Verify(_currentPerson);
 

--- a/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/Repositories/PunchItemRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/Repositories/PunchItemRepositoryTests.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure.Repositories;
 using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,11 +15,15 @@ namespace Equinor.ProCoSys.Completion.Infrastructure.Tests.Repositories;
 public class PunchItemRepositoryTests : EntityWithGuidRepositoryTestBase<PunchItem>
 {
     private Project _project;
+    private LibraryItem _raisedByOrg;
+    private LibraryItem _clearingByOrg;
 
     protected override void SetupRepositoryWithOneKnownItem()
     {
-        _project = new Project(TestPlant, Guid.NewGuid(), "ProjectName", "Description of project");
-        var punchItem = new PunchItem(TestPlant, _project, "Punch Item X");
+        _project = new Project(TestPlant, Guid.NewGuid(), null!, null!);
+        _raisedByOrg = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, null!);
+        _clearingByOrg = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, null!);
+        var punchItem = new PunchItem(TestPlant, _project, null!, _raisedByOrg, _clearingByOrg);
         _knownGuid = punchItem.Guid;
         punchItem.SetProtectedIdForTesting(_knownId);
 
@@ -34,5 +39,5 @@ public class PunchItemRepositoryTests : EntityWithGuidRepositoryTestBase<PunchIt
         _dut = new PunchItemRepository(_contextHelper.ContextMock.Object);
     }
 
-    protected override PunchItem GetNewEntity() => new(TestPlant, _project, "New punch item");
+    protected override PunchItem GetNewEntity() => new(TestPlant, _project, null!, _raisedByOrg, _clearingByOrg);
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
-using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Equinor.ProCoSys.Common.Misc;
 
 namespace Equinor.ProCoSys.Completion.Infrastructure.Tests;
 
@@ -18,6 +19,8 @@ public class UnitOfWorkTests
 {
     private readonly string _plant = "PCS$TESTPLANT";
     private Project _project;
+    private LibraryItem _raisedByOrg;
+    private LibraryItem _clearingByOrg;
     private readonly Guid _currentUserOid = new("12345678-1234-1234-1234-123456789123");
     private readonly DateTime _currentTime = new(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -30,7 +33,9 @@ public class UnitOfWorkTests
     [TestInitialize]
     public void Setup()
     {
-        _project = new(_plant, Guid.NewGuid(), "Project", "Description of Project");
+        _project = new(_plant, Guid.NewGuid(), null!, null!);
+        _raisedByOrg = new LibraryItem(_plant, Guid.NewGuid(), null!, null!, null!);
+        _clearingByOrg = new LibraryItem(_plant, Guid.NewGuid(), null!, null!, null!);
 
         _dbContextOptions = new DbContextOptionsBuilder<CompletionContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -61,7 +66,7 @@ public class UnitOfWorkTests
         _currentUserProviderMock
             .Setup(x => x.GetCurrentUserOid())
             .Returns(_currentUserOid);
-        var newPunchItem = new PunchItem(_plant, _project, "Title");
+        var newPunchItem = new PunchItem(_plant, _project, "Desc", _raisedByOrg, _clearingByOrg);
         dut.PunchItems.Add(newPunchItem);
 
         // Act
@@ -90,7 +95,7 @@ public class UnitOfWorkTests
             .Setup(x => x.GetCurrentUserOid())
             .Returns(_currentUserOid);
 
-        var newPunchItem = new PunchItem(_plant, _project, "Title");
+        var newPunchItem = new PunchItem(_plant, _project, "Desc", _raisedByOrg, _clearingByOrg);
         dut.PunchItems.Add(newPunchItem);
 
         await dut.SaveChangesAsync();

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
@@ -24,11 +24,11 @@ public class GetPunchItemQueryHandlerTests : ReadOnlyTestsBase
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
-        _createdPunchItem = new PunchItem(TestPlantA, _projectA, "created");
-        _modifiedPunchItem = new PunchItem(TestPlantA, _projectA, "modified");
-        _clearedPunchItem = new PunchItem(TestPlantA, _projectA, "cleared");
-        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, "verified");
-        _rejectedPunchItem = new PunchItem(TestPlantA, _projectA, "rejected");
+        _createdPunchItem = new PunchItem(TestPlantA, _projectA, "Desc", _raisedByOrg, _clearingByOrg);
+        _modifiedPunchItem = new PunchItem(TestPlantA, _projectA, "Desc", _raisedByOrg, _clearingByOrg);
+        _clearedPunchItem = new PunchItem(TestPlantA, _projectA, "Desc", _raisedByOrg, _clearingByOrg);
+        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, "Desc", _raisedByOrg, _clearingByOrg);
+        _rejectedPunchItem = new PunchItem(TestPlantA, _projectA, "Desc", _raisedByOrg, _clearingByOrg);
 
         context.PunchItems.Add(_createdPunchItem);
         context.PunchItems.Add(_modifiedPunchItem);

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure;
+using Equinor.ProCoSys.Completion.Query.PunchItemQueries.GetPunchItemsInProject;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ServiceResult;
-using Equinor.ProCoSys.Completion.Query.PunchItemQueries.GetPunchItemsInProject;
 
 namespace Equinor.ProCoSys.Completion.Query.Tests.PunchItemQueries.GetPunchItemsInProject;
 
@@ -22,8 +22,8 @@ public class GetPunchItemsInProjectQueryHandlerTests : ReadOnlyTestsBase
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
-        _punchItemInProjectA = new PunchItem(TestPlantA, _projectA, "A");
-        _punchItemInProjectB = new PunchItem(TestPlantA, _projectB, "B");
+        _punchItemInProjectA = new PunchItem(TestPlantA, _projectA, "A", _raisedByOrg, _clearingByOrg);
+        _punchItemInProjectB = new PunchItem(TestPlantA, _projectB, "B", _raisedByOrg, _clearingByOrg);
 
         context.PunchItems.Add(_punchItemInProjectA);
         context.PunchItems.Add(_punchItemInProjectB);

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Infrastructure;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 
 namespace Equinor.ProCoSys.Completion.Test.Common;
 
@@ -16,13 +17,19 @@ public abstract class ReadOnlyTestsBase : TestsBase
     protected readonly string ProjectNameA = "ProA";
     protected readonly string ProjectNameB = "ProB";
     protected readonly string ProjectNameC = "ProC";
+    protected readonly string RaisedByOrgCode = "COM";
+    protected readonly string ClearingByOrgCode = "ENG";
     protected static readonly Guid ProjectGuidA = Guid.NewGuid();
     protected static readonly Guid ProjectGuidB = Guid.NewGuid();
     protected static readonly Guid ProjectGuidC = Guid.NewGuid();
+    protected static readonly Guid RaisedByOrgGuid = Guid.NewGuid();
+    protected static readonly Guid ClearingByOrgGuid = Guid.NewGuid();
     protected Project _projectA;
     protected Project _projectB;
     protected Project _closedProjectC;
     protected Person _currentPerson;
+    protected LibraryItem _raisedByOrg;
+    protected LibraryItem _clearingByOrg;
     protected readonly Guid CurrentUserOid = new ("12345678-1234-1234-1234-123456789123");
     protected DbContextOptions<CompletionContext> _dbContextOptions;
     protected IPlantProvider _plantProviderMockObject;
@@ -62,6 +69,22 @@ public abstract class ReadOnlyTestsBase : TestsBase
         AddProject(context, _projectB);
         AddProject(context, _closedProjectC);
 
+        _raisedByOrg = new LibraryItem(
+            TestPlantA,
+            RaisedByOrgGuid, 
+            RaisedByOrgCode,
+            $"{RaisedByOrgCode} desc",
+            LibraryTypes.COMPLETION_ORGANIZATION.ToString());
+        _clearingByOrg = new LibraryItem(
+            TestPlantA,
+            ClearingByOrgGuid,
+            ClearingByOrgCode,
+            $"{ClearingByOrgCode} desc",
+            LibraryTypes.COMPLETION_ORGANIZATION.ToString());
+
+        AddLibraryItem(context, _raisedByOrg);
+        AddLibraryItem(context, _clearingByOrg);
+
         SetupNewDatabase(_dbContextOptions);
     }
 
@@ -85,5 +108,12 @@ public abstract class ReadOnlyTestsBase : TestsBase
         context.Projects.Add(project);
         context.SaveChangesAsync().Wait();
         return project;
+    }
+
+    protected LibraryItem AddLibraryItem(CompletionContext context, LibraryItem libraryItem)
+    {
+        context.Library.Add(libraryItem);
+        context.SaveChangesAsync().Wait();
+        return libraryItem;
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Completion.Domain;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Equinor.ProCoSys.Common.Misc;
-using Equinor.ProCoSys.Completion.Domain;
 
 namespace Equinor.ProCoSys.Completion.Test.Common;
 

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/CompletionContextExtension.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/CompletionContextExtension.cs
@@ -3,10 +3,11 @@ using System.Linq;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.AttachmentAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.CommentAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.LinkAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure;
 using Equinor.ProCoSys.Completion.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -48,7 +49,28 @@ public static class CompletionContextExtension
             KnownTestData.ProjectGuidA,
             KnownTestData.ProjectNameA,
             KnownTestData.ProjectDescriptionA);
-        var punchItemA = SeedPunchItem(dbContext, plant, project, KnownTestData.PunchItemA);
+
+        var raisedByOrg = SeedLibrary(
+            dbContext,
+            plant,
+            KnownTestData.RaisedByOrgGuid,
+            KnownTestData.RaisedByOrgCode,
+            LibraryTypes.COMPLETION_ORGANIZATION);
+
+        var clearingByOrg = SeedLibrary(
+            dbContext,
+            plant,
+            KnownTestData.ClearingByOrgGuid,
+            KnownTestData.ClearingByOrgCode,
+            LibraryTypes.COMPLETION_ORGANIZATION);
+
+        var punchItemA = SeedPunchItem(
+            dbContext,
+            plant,
+            project,
+            raisedByOrg,
+            clearingByOrg,
+            KnownTestData.PunchItemA);
         knownTestData.PunchItemAGuid = punchItemA.Guid;
 
         project = SeedProject(
@@ -57,7 +79,13 @@ public static class CompletionContextExtension
             KnownTestData.ProjectGuidB,
             KnownTestData.ProjectNameB, 
             KnownTestData.ProjectDescriptionB);
-        var punchItemB = SeedPunchItem(dbContext, plant, project, KnownTestData.PunchItemB);
+        var punchItemB = SeedPunchItem(
+            dbContext,
+            plant,
+            project,
+            raisedByOrg,
+            clearingByOrg,
+            KnownTestData.PunchItemB);
         knownTestData.PunchItemBGuid = punchItemB.Guid;
 
         var link = SeedLink(dbContext, nameof(PunchItem), punchItemA.Guid, "VG", "www.vg.no");
@@ -102,10 +130,16 @@ public static class CompletionContextExtension
         return project;
     }
 
-    private static PunchItem SeedPunchItem(CompletionContext dbContext, string plant, Project project, string title)
+    private static PunchItem SeedPunchItem(
+        CompletionContext dbContext,
+        string plant,
+        Project project,
+        LibraryItem raisedByOrg,
+        LibraryItem clearingByOrg,
+        string title)
     {
         var punchItemRepository = new PunchItemRepository(dbContext);
-        var punchItem = new PunchItem(plant, project, title);
+        var punchItem = new PunchItem(plant, project, title, raisedByOrg, clearingByOrg);
         punchItemRepository.Add(punchItem);
         dbContext.SaveChangesAsync().Wait();
         return punchItem;
@@ -141,5 +175,19 @@ public static class CompletionContextExtension
         attachmentRepository.Add(attachment);
         dbContext.SaveChangesAsync().Wait();
         return attachment;
+    }
+
+    private static LibraryItem SeedLibrary(
+        CompletionContext dbContext,
+        string plant,
+        Guid guid,
+        string code,
+        LibraryTypes type)
+    {
+        var libraryItemRepository = new LibraryItemRepository(dbContext);
+        var libraryItem = new LibraryItem(plant, guid, code, $"{code} desc", type.ToString());
+        libraryItemRepository.Add(libraryItem);
+        dbContext.SaveChangesAsync().Wait();
+        return libraryItem;
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/KnownTestData.cs
@@ -17,6 +17,11 @@ public class KnownTestData
     public static string ProjectDescriptionB => "Test - Project B";
     public static string PunchItemB => "PunchItem-B";
 
+    public static string RaisedByOrgCode => "COM";
+    public static Guid RaisedByOrgGuid => new("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    public static string ClearingByOrgCode => "ENG";
+    public static Guid ClearingByOrgGuid => new("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
     public Guid PunchItemAGuid { get; set; }
     public Guid PunchItemBGuid { get; set; }
     public Guid LinkInPunchItemAGuid { get; set; }

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerNegativeTests.cs
@@ -143,6 +143,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             TestFactory.Unknown,
             "PunchItem1",
             Guid.Empty,
+            Guid.Empty,
+            Guid.Empty,
             HttpStatusCode.Unauthorized);
 
     [TestMethod]
@@ -151,6 +153,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             UserType.NoPermissionUser,
             TestFactory.Unknown,
             "PunchItem1",
+            Guid.Empty,
+            Guid.Empty,
             Guid.Empty,
             HttpStatusCode.BadRequest,
             "is not a valid plant");
@@ -162,6 +166,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             TestFactory.Unknown,
             "PunchItem1",
             Guid.Empty,
+            Guid.Empty,
+            Guid.Empty,
             HttpStatusCode.BadRequest,
             "is not a valid plant");
 
@@ -172,6 +178,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             TestFactory.PlantWithoutAccess,
             "PunchItem1",
             Guid.Empty,
+            Guid.Empty,
+            Guid.Empty,
             HttpStatusCode.Forbidden);
 
     [TestMethod]
@@ -180,6 +188,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithoutAccess,
             "PunchItem1",
+            Guid.Empty,
+            Guid.Empty,
             Guid.Empty,
             HttpStatusCode.Forbidden);
 
@@ -190,6 +200,8 @@ public class PunchItemsControllerNegativeTests : TestBase
             TestFactory.PlantWithAccess,
             "PunchItem1",
             TestFactory.ProjectGuidWithAccess,
+            Guid.Empty,
+            Guid.Empty,
             HttpStatusCode.Forbidden);
     #endregion
 
@@ -332,7 +344,9 @@ public class PunchItemsControllerNegativeTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         Assert.AreNotEqual(guidAndRowVersion.RowVersion, TestFactory.WrongButValidRowVersion);
 
         // Act
@@ -1152,7 +1166,9 @@ public class PunchItemsControllerNegativeTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         Assert.AreNotEqual(rowVersionAfterClear, TestFactory.WrongButValidRowVersion);
 
         // Act
@@ -1230,7 +1246,9 @@ public class PunchItemsControllerNegativeTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         Assert.AreNotEqual(rowVersionAfterClear, TestFactory.WrongButValidRowVersion);
 
         // Act
@@ -1308,7 +1326,9 @@ public class PunchItemsControllerNegativeTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         Assert.AreNotEqual(rowVersionAfterClear, TestFactory.WrongButValidRowVersion);
 
         // Act
@@ -1386,7 +1406,9 @@ public class PunchItemsControllerNegativeTests : TestBase
         var (guid, rowVersionAfterVerify) = await PunchItemsControllerTestsHelper.CreateVerifiedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         Assert.AreNotEqual(rowVersionAfterVerify, TestFactory.WrongButValidRowVersion);
 
         // Act

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerTests.cs
@@ -35,7 +35,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             description,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         // Assert
         AssertValidGuidAndRowVersion(guidAndRowVersion);
@@ -105,7 +107,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guidAndRowVersion.Guid);
         Assert.IsNotNull(punchItem);
 
@@ -381,7 +385,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guidAndRowVersion.Guid);
         Assert.IsNotNull(punchItem);
         Assert.IsTrue(punchItem.IsReadyToBeCleared);
@@ -405,7 +411,9 @@ public class PunchItemsControllerTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guid);
         Assert.IsNotNull(punchItem);
@@ -430,7 +438,9 @@ public class PunchItemsControllerTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guid);
         Assert.IsNotNull(punchItem);
@@ -455,7 +465,9 @@ public class PunchItemsControllerTests : TestBase
         var (guid, rowVersionAfterClear) = await PunchItemsControllerTestsHelper.CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guid);
         Assert.IsNotNull(punchItem);
@@ -480,7 +492,9 @@ public class PunchItemsControllerTests : TestBase
         var (guid, rowVersionAfterVerify) = await PunchItemsControllerTestsHelper.CreateVerifiedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var punchItem = await PunchItemsControllerTestsHelper.GetPunchItemAsync(UserType.Writer, TestFactory.PlantWithAccess, guid);
         Assert.IsNotNull(punchItem);
@@ -506,7 +520,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var linkGuidAndRowVersion = await PunchItemsControllerTestsHelper.CreatePunchItemLinkAsync(
             UserType.Writer,
@@ -525,7 +541,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var commentGuidAndRowVersion = await PunchItemsControllerTestsHelper.CreatePunchItemCommentAsync(
             UserType.Writer,
@@ -543,7 +561,9 @@ public class PunchItemsControllerTests : TestBase
             UserType.Writer,
             TestFactory.PlantWithAccess,
             Guid.NewGuid().ToString(),
-            TestFactory.ProjectGuidWithAccess);
+            TestFactory.ProjectGuidWithAccess,
+            TestFactory.RaisedByOrgGuid,
+            TestFactory.ClearingByOrgGuid);
 
         var attachmentGuidAndRowVersion = await PunchItemsControllerTestsHelper.UploadNewPunchItemAttachmentAsync(
             UserType.Writer,

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/PunchItems/PunchItemsControllerTestsHelper.cs
@@ -84,13 +84,17 @@ public static class PunchItemsControllerTestsHelper
         string plant,
         string description,
         Guid projectGuid,
+        Guid raisedByOrgGuid,
+        Guid clearingByOrgGuid,
         HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
         string expectedMessageOnBadRequest = null)
     {
         var bodyPayload = new
         {
             description,
-            projectGuid = projectGuid.ToString()
+            projectGuid = projectGuid.ToString(),
+            raisedByOrgGuid = raisedByOrgGuid.ToString(),
+            clearingByOrgGuid = clearingByOrgGuid.ToString()
         };
 
         var serializePayload = JsonConvert.SerializeObject(bodyPayload);
@@ -491,12 +495,16 @@ public static class PunchItemsControllerTestsHelper
     public static async Task<(Guid guid, string rowVersion)> CreateVerifiedPunchItemAsync(
         UserType userType,
         string plant,
-        Guid projectGuid)
+        Guid projectGuid,
+        Guid raisedByOrgGuid,
+        Guid clearingByOrgGuid)
     {
         var (guid, rowVersionAfterClear) = await CreateClearedPunchItemAsync(
             UserType.Writer,
             TestFactory.PlantWithAccess,
-            projectGuid);
+            projectGuid,
+            raisedByOrgGuid,
+            clearingByOrgGuid);
         var rowVersionAfterVerify = await VerifyPunchItemAsync(
             userType,
             plant,
@@ -509,13 +517,17 @@ public static class PunchItemsControllerTestsHelper
     public static async Task<(Guid guid, string rowVersion)> CreateClearedPunchItemAsync(
         UserType userType,
         string plant,
-        Guid projectGuid)
+        Guid projectGuid,
+        Guid raisedByOrgGuid,
+        Guid clearingByOrgGuid)
     {
         var guidAndRowVersion = await CreatePunchItemAsync(
             userType,
             plant,
             Guid.NewGuid().ToString(),
-            projectGuid);
+            projectGuid,
+            raisedByOrgGuid,
+            clearingByOrgGuid);
         var rowVersionAfterClear = await ClearPunchItemAsync(
             userType,
             plant,

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/TestFactory.cs
@@ -45,6 +45,8 @@ public sealed class TestFactory : WebApplicationFactory<Startup>
     public static Guid ProjectGuidWithAccess => KnownTestData.ProjectGuidA;
     public static string ProjectNameWithoutAccess => KnownTestData.ProjectNameB;
     public static Guid ProjectGuidWithoutAccess => KnownTestData.ProjectGuidB;
+    public static Guid RaisedByOrgGuid => KnownTestData.RaisedByOrgGuid;
+    public static Guid ClearingByOrgGuid => KnownTestData.ClearingByOrgGuid;
     public static string AValidRowVersion => "AAAAAAAAAAA=";
     public static string WrongButValidRowVersion => "AAAAAAAAAAA=";
 

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForCreatePunchCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Authorizations/IsProjectCommandTests/AccessValidatorForCreatePunchCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
+﻿using System;
+using Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectCommandTests;
@@ -7,8 +8,8 @@ namespace Equinor.ProCoSys.Completion.WebApi.Tests.Authorizations.IsProjectComma
 public class AccessValidatorForCreatePunchItemCommandTests : AccessValidatorForIIsProjectCommandTests<CreatePunchItemCommand>
 {
     protected override CreatePunchItemCommand GetProjectRequestWithAccessToProjectToTest()
-        => new(null!, ProjectGuidWithAccess);
+        => new(null!, ProjectGuidWithAccess, Guid.Empty, Guid.Empty);
 
     protected override CreatePunchItemCommand GetProjectRequestWithoutAccessToProjectToTest()
-        => new(null!, ProjectGuidWithoutAccess);
+        => new(null!, ProjectGuidWithoutAccess, Guid.Empty, Guid.Empty);
 }

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Controllers/PunchItem/CreatePunchItemDtoValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Controllers/PunchItem/CreatePunchItemDtoValidatorTests.cs
@@ -14,7 +14,7 @@ public class CreatePunchItemDtoValidatorTests
     public async Task Validate_ShouldBeValid_WhenOkState()
     {
         // Arrange
-        var dto = new CreatePunchItemDto("New item", Guid.Empty);
+        var dto = new CreatePunchItemDto("New item", Guid.Empty, Guid.Empty, Guid.Empty);
         
         // Act
         var result = await _dut.ValidateAsync(dto);
@@ -27,7 +27,7 @@ public class CreatePunchItemDtoValidatorTests
     public async Task Validate_ShouldFail_WhenDescriptionNotGiven()
     {
         // Arrange
-        var dto = new CreatePunchItemDto(null!, Guid.NewGuid());
+        var dto = new CreatePunchItemDto(null!, Guid.Empty, Guid.Empty, Guid.Empty);
 
         // Act
         var result = await _dut.ValidateAsync(dto);
@@ -44,7 +44,7 @@ public class CreatePunchItemDtoValidatorTests
         // Arrange
         var dto = new CreatePunchItemDto(
             new string('x', Domain.AggregateModels.PunchItemAggregate.PunchItem.DescriptionLengthMax + 1),
-            Guid.NewGuid());
+            Guid.Empty, Guid.Empty, Guid.Empty);
 
         // Act
         var result = await _dut.ValidateAsync(dto);

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
@@ -21,7 +21,7 @@ public class PunchItemHelperTests : ReadOnlyTestsBase
         // Save to get real id on project
         context.SaveChangesAsync().Wait();
 
-        var punchItem = new PunchItem(TestPlantA, _projectA, "Title");
+        var punchItem = new PunchItem(TestPlantA, _projectA, "Title", _raisedByOrg, _clearingByOrg);
         context.PunchItems.Add(punchItem);
         context.SaveChangesAsync().Wait();
         _punchItemGuid = punchItem.Guid;


### PR DESCRIPTION
AB#103915

This PR Extend Punch tabell with 5 columns which refer to Library items.
The Punch constructor is extended with 2 of these columns which is required in DB: RaisedByOrg + ClearingByOrg.
Hence many tests needs update since constructor changes.

Next PR's will be
1) Update CreatePunchItemCommandValidator to check that given RaisedByOrg + ClearingByOrg guids exists
1) Extend CreatePunchItemCommand to also set Sorting, Priority and Type library items (which is not required in DB)
1) Update PunchItemDetailsDto in Query to also return Dto's for Library items 