### PR TITLE
104046 - UpdatePunchItemCommand.EnsureValidInputValidation in unit tests

### DIFF
--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Equinor.ProCoSys.Completion.Command.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Equinor.ProCoSys.Completion.Command.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Equinor.ProCoSys.Completion.Command\Equinor.ProCoSys.Completion.Command.csproj" />
     <ProjectReference Include="..\..\Equinor.ProCoSys.Completion.Domain\Equinor.ProCoSys.Completion.Domain.csproj" />
+    <ProjectReference Include="..\..\Equinor.ProCoSys.Completion.WebApi\Equinor.ProCoSys.Completion.WebApi.csproj" />
     <ProjectReference Include="..\Equinor.ProCoSys.Completion.Test.Common\Equinor.ProCoSys.Completion.Test.Common.csproj" />
   </ItemGroup>
 

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandExtension.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandExtension.cs
@@ -1,0 +1,24 @@
+﻿using Equinor.ProCoSys.Completion.Command.PunchItemCommands.UpdatePunchItem;
+using Equinor.ProCoSys.Completion.WebApi.Controllers;
+using Equinor.ProCoSys.Completion.WebApi.Controllers.PunchItems;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.UpdatePunchItem;
+
+public static class UpdatePunchItemCommandExtension
+{
+    // Helper extension for programmer to ensure correct setup of UpdatePunchItemCommand in unit tests
+    // This due to rather complex input rules for UpdatePunchItemCommand.PatchDocument
+    public static void EnsureValidInputValidation(this UpdatePunchItemCommand command)
+    {
+        var inputValidator = new PatchPunchItemDtoValidator(new RowVersionValidator(), new PatchOperationValidator());
+        var patchPunchItemDto = new PatchPunchItemDto
+        {
+            PatchDocument = command.PatchDocument,
+            RowVersion = command.RowVersion
+        };
+
+        var inputValidationResult = inputValidator.Validate(patchPunchItemDto);
+        Assert.IsTrue(inputValidationResult.IsValid);
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
@@ -45,6 +45,8 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         _command.PatchDocument.Replace(p => p.SortingGuid, _sortingGuid);
         _command.PatchDocument.Replace(p => p.TypeGuid, _typeGuid);
 
+        _command.EnsureValidInputValidation();
+
         _libraryItemRepositoryMock = Substitute.For<ILibraryItemRepository>();
 
         _raisedByOrg = SetupLibraryItem(_raisedByOrgGuid, LibraryType.COMPLETION_ORGANIZATION, 100);

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandValidatorTests.cs
@@ -27,12 +27,14 @@ public class UpdatePunchItemCommandValidatorTests
     [TestInitialize]
     public void Setup_OkState()
     {
-        _command = new UpdatePunchItemCommand(Guid.NewGuid(), _jsonPatchDocument, "r");
+        _command = new UpdatePunchItemCommand(Guid.NewGuid(), _jsonPatchDocument, "AAAAAAAAABA=");
         _command.PatchDocument.Replace(p => p.RaisedByOrgGuid, _raisedByOrgGuid);
         _command.PatchDocument.Replace(p => p.ClearingByOrgGuid, _clearingByOrgGuid);
         _command.PatchDocument.Replace(p => p.PriorityGuid, _priorityGuid);
         _command.PatchDocument.Replace(p => p.SortingGuid, _sortingGuid);
         _command.PatchDocument.Replace(p => p.TypeGuid, _typeGuid);
+
+        _command.EnsureValidInputValidation();
 
         _punchItemValidatorMock = Substitute.For<IPunchItemValidator>();
         _punchItemValidatorMock.ExistsAsync(_command.PunchItemGuid, default)


### PR DESCRIPTION
[AB#104046](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/104046)

@jsoi-eq Is this a good idea or not?

It will prevent the programmer to setup illegal unit test data that input validator will stop in real life
For instance: 
`_command.PatchDocument.Replace(p => p.PriorityGuid, DateTime.Now);`