### PR TITLE
104046 patch punch vol6 navigation props for message to bus

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/EventHandlers/DomainEvents/PunchItemEvents/IntegrationEvents/PunchItemCreatedIntegrationEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/EventHandlers/DomainEvents/PunchItemEvents/IntegrationEvents/PunchItemCreatedIntegrationEvent.cs
@@ -8,6 +8,8 @@ public record PunchItemCreatedIntegrationEvent
 (
     string DisplayName,
     Guid ProjectGuid,
+    string ProjectName,
+    string ProjectDescription,
     Guid Guid,
     int ItemNo,
     Guid CreatedByOid,
@@ -16,7 +18,9 @@ public record PunchItemCreatedIntegrationEvent
 {
     internal PunchItemCreatedIntegrationEvent(PunchItemCreatedDomainEvent punchItemCreatedEvent) : this(
         DisplayName: "Punch item created",
-        punchItemCreatedEvent.ProjectGuid,
+        punchItemCreatedEvent.PunchItem.Project.Guid,
+        punchItemCreatedEvent.PunchItem.Project.Name,
+        punchItemCreatedEvent.PunchItem.Project.Description,
         punchItemCreatedEvent.PunchItem.Guid,
         punchItemCreatedEvent.PunchItem.ItemNo,
         punchItemCreatedEvent.PunchItem.CreatedByOid,

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -63,7 +63,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         await SetLibraryItemAsync(punchItem, request.TypeGuid, LibraryType.PUNCHLIST_TYPE);
 
         _punchItemRepository.Add(punchItem);
-        punchItem.AddDomainEvent(new PunchItemCreatedDomainEvent(punchItem, request.ProjectGuid));
+        punchItem.AddDomainEvent(new PunchItemCreatedDomainEvent(punchItem));
 
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
@@ -30,21 +30,18 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
         LibraryItem clearingByOrg)
         : base(plant)
     {
-        if (project.Plant != plant)
-        {
-            throw new ArgumentException($"Can't relate {nameof(project)} in {project.Plant} to item in {plant}");
-        }
-        ProjectId = project.Id;
         CheckListGuid = checkListGuid;
         Description = description;
         Guid = Guid.NewGuid();
 
+        SetProject(plant, project);
         SetRaisedByOrg(raisedByOrg);
         SetClearingByOrg(clearingByOrg);
     }
 
     // private setters needed for Entity Framework
     public int ProjectId { get; private set; }
+    public Project Project { get; private set; } = null!;
     // Guid to CheckList in ProCoSys 4 owning the Punch. Will probably be an internal Id to Internal CheckList table when CheckList migrated to Completion
     public Guid CheckListGuid { get; private set; }
     public int ItemNo => Id;
@@ -239,5 +236,16 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
     {
         Type = null;
         TypeId = null;
+    }
+
+    private void SetProject(string plant, Project project)
+    {
+        if (project.Plant != plant)
+        {
+            throw new ArgumentException($"Can't relate {nameof(project)} in {project.Plant} to item in {plant}");
+        }
+
+        ProjectId = project.Id;
+        Project = project;
     }
 }

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
@@ -49,10 +49,15 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
     public Guid CheckListGuid { get; private set; }
     public int ItemNo => Id;
     public string Description { get; set; }
+    public LibraryItem RaisedByOrg { get; private set; } = null!;
     public int RaisedByOrgId { get; private set; }
+    public LibraryItem ClearingByOrg { get; private set; } = null!;
     public int ClearingByOrgId { get; private set; }
+    public LibraryItem? Sorting { get; private set; }
     public int? SortingId { get; private set; }
+    public LibraryItem? Type { get; private set; }
     public int? TypeId { get; private set; }
+    public LibraryItem? Priority { get; private set; }
     public int? PriorityId { get; private set; }
 
     public DateTime CreatedAtUtc { get; private set; }
@@ -154,6 +159,7 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
             throw new ArgumentException($"Can't relate a {raisedByOrg.Type} as {nameof(raisedByOrg)}");
         }
 
+        RaisedByOrg = raisedByOrg;
         RaisedByOrgId = raisedByOrg.Id;
     }
 
@@ -168,6 +174,7 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
             throw new ArgumentException($"Can't relate a {clearingByOrg.Type} as {nameof(clearingByOrg)}");
         }
 
+        ClearingByOrg = clearingByOrg;
         ClearingByOrgId = clearingByOrg.Id;
     }
 
@@ -182,6 +189,7 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
             throw new ArgumentException($"Can't relate a {sorting.Type} as {nameof(sorting)}");
         }
 
+        Sorting = sorting;
         SortingId = sorting.Id;
     }
 
@@ -196,6 +204,7 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
             throw new ArgumentException($"Can't relate a {type.Type} as {nameof(type)}");
         }
 
+        Type = type;
         TypeId = type.Id;
     }
 
@@ -210,10 +219,25 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
             throw new ArgumentException($"Can't relate a {priority.Type} as {nameof(priority)}");
         }
 
+        Priority = priority;
         PriorityId = priority.Id;
     }
 
-    public void ClearSorting() => SortingId = null;
-    public void ClearPriority() => PriorityId = null;
-    public void ClearType() => TypeId = null;
+    public void ClearSorting()
+    {
+        Sorting = null;
+        SortingId = null;
+    }
+
+    public void ClearPriority()
+    {
+        Priority = null;
+        PriorityId = null;
+    }
+
+    public void ClearType()
+    {
+        Type = null;
+        TypeId = null;
+    }
 }

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/DomainEvents/PunchItemDomainEvents/PunchItemCreatedDomainEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/DomainEvents/PunchItemDomainEvents/PunchItemCreatedDomainEvent.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 
 namespace Equinor.ProCoSys.Completion.Domain.Events.DomainEvents.PunchItemDomainEvents;
 
 public class PunchItemCreatedDomainEvent : PunchItemDomainEvent
 {
-    // ToDo #104017 extend with Guids for Library-values such as PunchPriority etc #.
-    public PunchItemCreatedDomainEvent(PunchItem punchItem, Guid projectGuid) : base(punchItem)
-        => ProjectGuid = projectGuid;
-
-    public Guid ProjectGuid { get; }
+    public PunchItemCreatedDomainEvent(PunchItem punchItem) : base(punchItem)
+    {
+    }
 }

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
@@ -1,7 +1,6 @@
-﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure.EntityConfigurations.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -24,31 +23,26 @@ internal class PunchItemConfiguration : IEntityTypeConfiguration<PunchItem>
             .IsRequired()
             .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasOne<LibraryItem>()
+        builder.HasOne(x => x.RaisedByOrg)
             .WithMany()
-            .HasForeignKey(x => x.RaisedByOrgId)
             .IsRequired()
             .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasOne<LibraryItem>()
+        builder.HasOne(x => x.ClearingByOrg)
             .WithMany()
-            .HasForeignKey(x => x.ClearingByOrgId)
             .IsRequired()
             .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasOne<LibraryItem>()
+        builder.HasOne(x => x.Sorting)
             .WithMany()
-            .HasForeignKey(x => x.SortingId)
             .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasOne<LibraryItem>()
+        builder.HasOne(x => x.Type)
             .WithMany()
-            .HasForeignKey(x => x.TypeId)
             .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasOne<LibraryItem>()
+        builder.HasOne(x => x.Priority)
             .WithMany()
-            .HasForeignKey(x => x.PriorityId)
             .OnDelete(DeleteBehavior.NoAction);
 
         builder.Property(x => x.Id)
@@ -88,37 +82,6 @@ internal class PunchItemConfiguration : IEntityTypeConfiguration<PunchItem>
             .WithMany()
             .HasForeignKey(x => x.VerifiedById)
             .OnDelete(DeleteBehavior.NoAction);
-
-        builder
-            .HasOne<LibraryItem>()
-            .WithMany()
-            .HasForeignKey(x => x.RaisedByOrgId)
-            .OnDelete(DeleteBehavior.NoAction);
-
-        builder
-            .HasOne<LibraryItem>()
-            .WithMany()
-            .HasForeignKey(x => x.ClearingByOrgId)
-            .OnDelete(DeleteBehavior.NoAction);
-
-        builder
-            .HasOne<LibraryItem>()
-            .WithMany()
-            .HasForeignKey(x => x.SortingId)
-            .OnDelete(DeleteBehavior.NoAction);
-
-        builder
-            .HasOne<LibraryItem>()
-            .WithMany()
-            .HasForeignKey(x => x.TypeId)
-            .OnDelete(DeleteBehavior.NoAction);
-
-        builder
-            .HasOne<LibraryItem>()
-            .WithMany()
-            .HasForeignKey(x => x.PriorityId)
-            .OnDelete(DeleteBehavior.NoAction);
-
         // both ClearedAtUtc and ClearedById fields must either be set or not set
         builder
             .ToTable(x => x.HasCheckConstraint("punch_item_check_cleared",

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/EntityConfigurations/PunchItemConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure.EntityConfigurations.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -17,9 +16,8 @@ internal class PunchItemConfiguration : IEntityTypeConfiguration<PunchItem>
         builder.ConfigureModificationAudit();
         builder.ConfigureConcurrencyToken();
 
-        builder.HasOne<Project>()
+        builder.HasOne(x => x.Project)
             .WithMany()
-            .HasForeignKey(x => x.ProjectId)
             .IsRequired()
             .OnDelete(DeleteBehavior.NoAction);
 

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230922091555_PunchWithNavigationProperties.Designer.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230922091555_PunchWithNavigationProperties.Designer.cs
@@ -4,6 +4,7 @@ using Equinor.ProCoSys.Completion.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Equinor.ProCoSys.Completion.Infrastructure.Migrations
 {
     [DbContext(typeof(CompletionContext))]
-    partial class CompletionContextModelSnapshot : ModelSnapshot
+    [Migration("20230922091555_PunchWithNavigationProperties")]
+    partial class PunchWithNavigationProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230922091555_PunchWithNavigationProperties.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Migrations/20230922091555_PunchWithNavigationProperties.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equinor.ProCoSys.Completion.Infrastructure.Migrations
+{
+    // This empty migration is kept to just proof that changes in code didn't change the DB 
+
+    /// <inheritdoc />
+    public partial class PunchWithNavigationProperties : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Repositories/PunchItemRepository.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Repositories/PunchItemRepository.cs
@@ -1,11 +1,19 @@
 ﻿using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equinor.ProCoSys.Completion.Infrastructure.Repositories;
 
 public class PunchItemRepository : EntityWithGuidRepository<PunchItem>, IPunchItemRepository
 {
     public PunchItemRepository(CompletionContext context)
-        : base(context, context.PunchItems)
+        : base(context, 
+            context.PunchItems,
+            context.PunchItems
+                .Include(p => p.RaisedByOrg)
+                .Include(p => p.ClearingByOrg)
+                .Include(p => p.Priority)
+                .Include(p => p.Sorting)
+                .Include(p => p.Type))
     {
     }
 }

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/IPunchItemCreatedV1.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/IPunchItemCreatedV1.cs
@@ -5,6 +5,8 @@ namespace Equinor.ProCoSys.Completion.MessageContracts;
 public interface IPunchItemCreatedV1 : IHaveDisplayName, IIntegrationEvent
 {
     public Guid ProjectGuid { get; }
+    string ProjectName { get; }
+    string ProjectDescription { get; }
     public Guid Guid { get;  }
     public int ItemNo { get; }
     public Guid CreatedByOid { get; }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemCreatedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/EventHandlers/DomainEvents/PunchItemEvents/PunchItemCreatedEventHandlerTests.cs
@@ -22,7 +22,7 @@ public class PunchItemCreatedEventHandlerTests : EventHandlerTestBase
     {
         _punchItem.SetCreated(_person);
 
-        _punchItemCreatedEvent = new PunchItemCreatedDomainEvent(_punchItem, _project.Guid);
+        _punchItemCreatedEvent = new PunchItemCreatedDomainEvent(_punchItem);
         _publishEndpointMock = Substitute.For<IPublishEndpoint>();
         _dut = new PunchItemCreatedEventHandler(_publishEndpointMock, Substitute.For<ILogger<PunchItemCreatedEventHandler>>());
         _publishEndpointMock
@@ -55,7 +55,7 @@ public class PunchItemCreatedEventHandlerTests : EventHandlerTestBase
         // Assert
         Assert.IsNotNull(_publishedIntegrationEvent);
         Assert.AreEqual("Punch item created", _publishedIntegrationEvent.DisplayName);
-        Assert.AreEqual(_punchItemCreatedEvent.ProjectGuid, _publishedIntegrationEvent.ProjectGuid);
+        Assert.AreEqual(_punchItemCreatedEvent.PunchItem.Project.Guid, _publishedIntegrationEvent.ProjectGuid);
         Assert.AreEqual(_punchItemCreatedEvent.PunchItem.Guid, _publishedIntegrationEvent.Guid);
         Assert.AreEqual(_punchItemCreatedEvent.PunchItem.CreatedAtUtc, _publishedIntegrationEvent.CreatedAtUtc);
         Assert.AreEqual(_punchItemCreatedEvent.PunchItem.CreatedByOid, _publishedIntegrationEvent.CreatedByOid);

--- a/src/tests/Equinor.ProCoSys.Completion.Domain.Tests/AggregateModels/PunchItemAggregate/PunchItemTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Domain.Tests/AggregateModels/PunchItemAggregate/PunchItemTests.cs
@@ -58,8 +58,10 @@ public class PunchItemTests : IModificationAuditableTests
         Assert.AreEqual(_project.Id, _dut.ProjectId);
         Assert.AreEqual(_checkListGuid, _dut.CheckListGuid);
         Assert.AreEqual(_itemDescription, _dut.Description);
+        Assert.AreEqual(_raisedByOrg, _dut.RaisedByOrg);
         Assert.AreEqual(_raisedByOrg.Id, _dut.RaisedByOrgId);
         Assert.AreEqual(_clearingByOrg.Id, _dut.ClearingByOrgId);
+        Assert.AreEqual(_clearingByOrg, _dut.ClearingByOrg);
     }
 
     [TestMethod]
@@ -490,7 +492,7 @@ public class PunchItemTests : IModificationAuditableTests
 
     #region SetRaisedByOrg
     [TestMethod]
-    public void SetRaisedByOrg_ShouldSetRaisedByOrgId()
+    public void SetRaisedByOrg_ShouldSetRaisedByOrg()
     {
         // Arrange 
         Assert.AreEqual(_raisedByOrg.Id, _dut.RaisedByOrgId);
@@ -503,6 +505,7 @@ public class PunchItemTests : IModificationAuditableTests
 
         // Assert
         Assert.AreEqual(newRaisedByOrg.Id, _dut.RaisedByOrgId);
+        Assert.AreEqual(newRaisedByOrg, _dut.RaisedByOrg);
     }
 
     [TestMethod]
@@ -520,7 +523,7 @@ public class PunchItemTests : IModificationAuditableTests
 
     #region SetClearingByOrg
     [TestMethod]
-    public void SetClearingByOrg_ShouldSetClearingByOrgId()
+    public void SetClearingByOrg_ShouldSetClearingByOrg()
     {
         // Arrange 
         Assert.AreEqual(_clearingByOrg.Id, _dut.ClearingByOrgId);
@@ -532,6 +535,7 @@ public class PunchItemTests : IModificationAuditableTests
 
         // Assert
         Assert.AreEqual(newClearingByOrg.Id, _dut.ClearingByOrgId);
+        Assert.AreEqual(newClearingByOrg, _dut.ClearingByOrg);
     }
 
     [TestMethod]
@@ -549,13 +553,17 @@ public class PunchItemTests : IModificationAuditableTests
 
     #region SetPriority
     [TestMethod]
-    public void SetPriority_ShouldSetPriorityId()
+    public void SetPriority_ShouldSetPriority()
     {
+        // Arrange
+        Assert.IsNull(_dut.PriorityId);
+
         // Act
         _dut.SetPriority(_priority);
 
         // Assert
         Assert.AreEqual(_priority.Id, _dut.PriorityId);
+        Assert.AreEqual(_priority, _dut.Priority);
     }
 
     [TestMethod]
@@ -573,13 +581,17 @@ public class PunchItemTests : IModificationAuditableTests
 
     #region SetSorting
     [TestMethod]
-    public void SetSorting_ShouldSetSortingId()
+    public void SetSorting_ShouldSetSorting()
     {
+        // Arrange
+        Assert.IsNull(_dut.SortingId);
+
         // Act
         _dut.SetSorting(_sorting);
 
         // Assert
         Assert.AreEqual(_sorting.Id, _dut.SortingId);
+        Assert.AreEqual(_sorting, _dut.Sorting);
     }
 
     [TestMethod]
@@ -599,11 +611,15 @@ public class PunchItemTests : IModificationAuditableTests
     [TestMethod]
     public void SetType_ShouldSetTypeId()
     {
+        // Arrange
+        Assert.IsNull(_dut.TypeId);
+
         // Act
         _dut.SetType(_type);
 
         // Assert
         Assert.AreEqual(_type.Id, _dut.TypeId);
+        Assert.AreEqual(_type, _dut.Type);
     }
 
     [TestMethod]
@@ -621,49 +637,55 @@ public class PunchItemTests : IModificationAuditableTests
 
     #region ClearPriority
     [TestMethod]
-    public void ClearPriority_ShouldClearPriorityId()
+    public void ClearPriority_ShouldClearPriority()
     {
         // Arrange
         _dut.SetPriority(_priority);
         Assert.AreEqual(_priority.Id, _dut.PriorityId);
-        
+        Assert.IsNotNull(_dut.Priority);
+
         // Act
         _dut.ClearPriority();
 
         // Assert
         Assert.IsNull(_dut.PriorityId);
+        Assert.IsNull(_dut.Priority);
     }
     #endregion
 
     #region ClearSorting
     [TestMethod]
-    public void ClearSorting_ShouldClearSortingId()
+    public void ClearSorting_ShouldClearSorting()
     {
         // Arrange
         _dut.SetSorting(_sorting);
         Assert.AreEqual(_sorting.Id, _dut.SortingId);
+        Assert.IsNotNull(_dut.Sorting);
 
         // Act
         _dut.ClearSorting();
 
         // Assert
         Assert.IsNull(_dut.SortingId);
+        Assert.IsNull(_dut.Sorting);
     }
     #endregion
 
     #region ClearType
     [TestMethod]
-    public void ClearType_ShouldClearTypeId()
+    public void ClearType_ShouldClearType()
     {
         // Arrange
         _dut.SetType(_type);
         Assert.AreEqual(_type.Id, _dut.TypeId);
+        Assert.IsNotNull(_dut.Type);
 
         // Act
         _dut.ClearType();
 
         // Assert
         Assert.IsNull(_dut.TypeId);
+        Assert.IsNull(_dut.Type);
     }
     #endregion
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Domain.Tests/AggregateModels/PunchItemAggregate/PunchItemTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Domain.Tests/AggregateModels/PunchItemAggregate/PunchItemTests.cs
@@ -56,6 +56,7 @@ public class PunchItemTests : IModificationAuditableTests
         // Assert
         Assert.AreEqual(_testPlant, _dut.Plant);
         Assert.AreEqual(_project.Id, _dut.ProjectId);
+        Assert.AreEqual(_project, _dut.Project);
         Assert.AreEqual(_checkListGuid, _dut.CheckListGuid);
         Assert.AreEqual(_itemDescription, _dut.Description);
         Assert.AreEqual(_raisedByOrg, _dut.RaisedByOrg);

--- a/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/Repositories/PunchItemRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/Repositories/PunchItemRepositoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
@@ -18,6 +19,9 @@ public class PunchItemRepositoryTests : EntityWithGuidRepositoryTestBase<PunchIt
     private Project _project;
     private LibraryItem _raisedByOrg;
     private LibraryItem _clearingByOrg;
+    private LibraryItem _priority;
+    private LibraryItem _sorting;
+    private LibraryItem _type;
 
     protected override void SetupRepositoryWithOneKnownItem()
     {
@@ -25,6 +29,13 @@ public class PunchItemRepositoryTests : EntityWithGuidRepositoryTestBase<PunchIt
         _raisedByOrg = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, LibraryType.COMPLETION_ORGANIZATION);
         _clearingByOrg = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, LibraryType.COMPLETION_ORGANIZATION);
         var punchItem = new PunchItem(TestPlant, _project, Guid.NewGuid(), null!, _raisedByOrg, _clearingByOrg);
+        _priority = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, LibraryType.PUNCHLIST_PRIORITY);
+        punchItem.SetPriority(_priority);
+        _sorting = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, LibraryType.PUNCHLIST_SORTING);
+        punchItem.SetSorting(_sorting);
+        _type = new LibraryItem(TestPlant, Guid.NewGuid(), null!, null!, LibraryType.PUNCHLIST_TYPE);
+        punchItem.SetType(_type);
+
         _knownGuid = punchItem.Guid;
         punchItem.SetProtectedIdForTesting(_knownId);
 
@@ -41,4 +52,19 @@ public class PunchItemRepositoryTests : EntityWithGuidRepositoryTestBase<PunchIt
     }
 
     protected override PunchItem GetNewEntity() => new(TestPlant, _project, Guid.NewGuid(), null!, _raisedByOrg, _clearingByOrg);
+
+    [TestMethod]
+    public async Task GetByGuid_KnownGuid_ShouldReturnEntityWithLibraryProperties()
+    {
+        // Act
+        var result = await _dut.GetByGuidAsync(_knownGuid);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(_raisedByOrg, result.RaisedByOrg);
+        Assert.AreEqual(_clearingByOrg, result.ClearingByOrg);
+        Assert.AreEqual(_priority, result.Priority);
+        Assert.AreEqual(_sorting, result.Sorting);
+        Assert.AreEqual(_type, result.Type);
+    }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
@@ -5,8 +5,6 @@ using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Common.Time;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -18,9 +16,6 @@ namespace Equinor.ProCoSys.Completion.Infrastructure.Tests;
 public class UnitOfWorkTests
 {
     private readonly string _plant = "PCS$TESTPLANT";
-    private Project _project;
-    private LibraryItem _raisedByOrg;
-    private LibraryItem _clearingByOrg;
     private readonly Guid _currentUserOid = new("12345678-1234-1234-1234-123456789123");
     private readonly DateTime _currentTime = new(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -29,14 +24,11 @@ public class UnitOfWorkTests
     private IEventDispatcher _eventDispatcherMock;
     private ICurrentUserProvider _currentUserProviderMock;
     private ManualTimeProvider _timeProvider;
+    private Person _user;
 
     [TestInitialize]
-    public void Setup()
+    public async Task Setup()
     {
-        _project = new(_plant, Guid.NewGuid(), null!, null!);
-        _raisedByOrg = new LibraryItem(_plant, Guid.NewGuid(), null!, null!, LibraryType.COMPLETION_ORGANIZATION);
-        _clearingByOrg = new LibraryItem(_plant, Guid.NewGuid(), null!, null!, LibraryType.COMPLETION_ORGANIZATION);
-
         _dbContextOptions = new DbContextOptionsBuilder<CompletionContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
@@ -51,6 +43,15 @@ public class UnitOfWorkTests
 
         _timeProvider = new ManualTimeProvider(_currentTime);
         TimeService.SetProvider(_timeProvider);
+
+        await using var dut = new CompletionContext(_dbContextOptions, _plantProviderMock, _eventDispatcherMock, _currentUserProviderMock);
+
+        _user = new Person(_currentUserOid, "Current", "User", "cu", "cu@pcs.pcs");
+        dut.Persons.Add(_user);
+        await dut.SaveChangesAsync();
+
+        _currentUserProviderMock.GetCurrentUserOid()
+            .Returns(_currentUserOid);
     }
 
     [TestMethod]
@@ -59,25 +60,19 @@ public class UnitOfWorkTests
         // Arrange
         await using var dut = new CompletionContext(_dbContextOptions, _plantProviderMock, _eventDispatcherMock, _currentUserProviderMock);
 
-        var user = new Person(_currentUserOid, "Current", "User", "cu", "cu@pcs.pcs");
-        dut.Persons.Add(user);
-        await dut.SaveChangesAsync();
-
-        _currentUserProviderMock.GetCurrentUserOid()
-            .Returns(_currentUserOid);
-        var newPunchItem = new PunchItem(_plant, _project, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
-        dut.PunchItems.Add(newPunchItem);
+        var raisedByOrg = new LibraryItem(_plant, Guid.NewGuid(), "EQ", "Equinor", LibraryType.COMPLETION_ORGANIZATION);
+        dut.Library.Add(raisedByOrg);
 
         // Act
         await dut.SaveChangesAsync();
 
         // Assert
-        Assert.AreEqual(_currentTime, newPunchItem.CreatedAtUtc);
-        Assert.AreEqual(user.Id, newPunchItem.CreatedById);
-        Assert.AreEqual(_currentUserOid, newPunchItem.CreatedByOid);
-        Assert.IsNull(newPunchItem.ModifiedAtUtc);
-        Assert.IsNull(newPunchItem.ModifiedById);
-        Assert.IsNull(newPunchItem.ModifiedByOid);
+        Assert.AreEqual(_currentTime, raisedByOrg.CreatedAtUtc);
+        Assert.AreEqual(_user.Id, raisedByOrg.CreatedById);
+        Assert.AreEqual(_currentUserOid, raisedByOrg.CreatedByOid);
+        Assert.IsNull(raisedByOrg.ModifiedAtUtc);
+        Assert.IsNull(raisedByOrg.ModifiedById);
+        Assert.IsNull(raisedByOrg.ModifiedByOid);
     }
 
     [TestMethod]
@@ -86,26 +81,19 @@ public class UnitOfWorkTests
         // Arrange
         await using var dut = new CompletionContext(_dbContextOptions, _plantProviderMock, _eventDispatcherMock, _currentUserProviderMock);
 
-        var user = new Person(_currentUserOid, "Current", "User", "cu", "cu@pcs.pcs");
-        dut.Persons.Add(user);
-        await dut.SaveChangesAsync();
-
-        _currentUserProviderMock.GetCurrentUserOid()
-            .Returns(_currentUserOid);
-
-        var newPunchItem = new PunchItem(_plant, _project, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
-        dut.PunchItems.Add(newPunchItem);
+        var raisedByOrg = new LibraryItem(_plant, Guid.NewGuid(), "EQ", "Equinor", LibraryType.COMPLETION_ORGANIZATION);
+        dut.Library.Add(raisedByOrg);
 
         await dut.SaveChangesAsync();
 
-        newPunchItem.Description = "Updated";
+        raisedByOrg.IsVoided = true;
             
         // Act
         await dut.SaveChangesAsync();
 
         // Assert
-        Assert.AreEqual(_currentTime, newPunchItem.ModifiedAtUtc);
-        Assert.AreEqual(user.Id, newPunchItem.ModifiedById);
-        Assert.AreEqual(_currentUserOid, newPunchItem.ModifiedByOid);
+        Assert.AreEqual(_currentTime, raisedByOrg.ModifiedAtUtc);
+        Assert.AreEqual(_user.Id, raisedByOrg.ModifiedById);
+        Assert.AreEqual(_currentUserOid, raisedByOrg.ModifiedByOid);
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Infrastructure.Tests/UnitOfWorkTests.cs
@@ -86,6 +86,7 @@ public class UnitOfWorkTests
 
         await dut.SaveChangesAsync();
 
+        // trigger a change on record. EF change tracker notice this
         raisedByOrg.IsVoided = true;
             
         // Act

--- a/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/PunchItem/PunchItemCreatedV1ContractTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/PunchItem/PunchItemCreatedV1ContractTests.cs
@@ -16,6 +16,8 @@ public class PunchItemCreatedV1ContractTests : ContractTestBase<IPunchItemCreate
             { "DisplayName", typeof(string) },
             { "Guid", typeof(Guid) },
             { "ProjectGuid", typeof(Guid) },
+            { "ProjectName", typeof(string) },
+            { "ProjectDescription", typeof(string) },
             { "ItemNo", typeof(int) },
             { "CreatedByOid", typeof(Guid) },
             { "CreatedAtUtc", typeof(DateTime) }

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
@@ -26,11 +27,21 @@ public class GetPunchItemQueryHandlerTests : ReadOnlyTestsBase
     private PunchItem _punchItemWithoutPriority;
     private PunchItem _punchItemWithoutSorting;
     private PunchItem _punchItemWithoutType;
+    private LibraryItem _raisedByOrg;
+    private LibraryItem _clearingByOrg;
+    private LibraryItem _priority;
+    private LibraryItem _sorting;
+    private LibraryItem _type;
 
     protected override void SetupNewDatabase(DbContextOptions<CompletionContext> dbContextOptions)
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
+        _raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
+        _clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
+        _priority = context.Library.Single(l => l.Id == _priorityId);
+        _sorting = context.Library.Single(l => l.Id == _sortingId);
+        _type = context.Library.Single(l => l.Id == _typeId);
         _createdPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
         _createdPunchItem.SetPriority(_priority);
         _createdPunchItem.SetSorting(_sorting);

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItem/GetPunchItemQueryHandlerTests.cs
@@ -37,19 +37,20 @@ public class GetPunchItemQueryHandlerTests : ReadOnlyTestsBase
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
+        var projectA = context.Projects.Single(p => p.Id == _projectAId);
         _raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
         _clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
         _priority = context.Library.Single(l => l.Id == _priorityId);
         _sorting = context.Library.Single(l => l.Id == _sortingId);
         _type = context.Library.Single(l => l.Id == _typeId);
-        _createdPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
+        _createdPunchItem = new PunchItem(TestPlantA, projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
         _createdPunchItem.SetPriority(_priority);
         _createdPunchItem.SetSorting(_sorting);
         _createdPunchItem.SetType(_type);
-        _modifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
-        _clearedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
-        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
-        _rejectedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
+        _modifiedPunchItem = new PunchItem(TestPlantA, projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
+        _clearedPunchItem = new PunchItem(TestPlantA, projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
+        _verifiedPunchItem = new PunchItem(TestPlantA, projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
+        _rejectedPunchItem = new PunchItem(TestPlantA, projectA, Guid.NewGuid(), "Desc", _raisedByOrg, _clearingByOrg);
 
         _punchItemWithPriority = _punchItemWithSorting = _punchItemWithType = _createdPunchItem;
         _punchItemWithoutPriority = _punchItemWithoutSorting = _punchItemWithoutType = _modifiedPunchItem;

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure;
 using Equinor.ProCoSys.Completion.Query.PunchItemQueries.GetPunchItemsInProject;
@@ -17,11 +18,15 @@ public class GetPunchItemsInProjectQueryHandlerTests : ReadOnlyTestsBase
 {
     private PunchItem _punchItemInProjectA;
     private PunchItem _punchItemInProjectB;
+    private Project _projectA;
+    private Project _projectB;
 
     protected override void SetupNewDatabase(DbContextOptions<CompletionContext> dbContextOptions)
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
+        _projectA = context.Projects.Single(p => p.Id == _projectAId);
+        _projectB = context.Projects.Single(p => p.Id == _projectBId);
         var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
         var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
 

--- a/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Query.Tests/PunchItemQueries/GetPunchItemsInProject/GetPunchItemsInProjectQueryHandlerTests.cs
@@ -22,8 +22,11 @@ public class GetPunchItemsInProjectQueryHandlerTests : ReadOnlyTestsBase
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
-        _punchItemInProjectA = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "A", _raisedByOrg, _clearingByOrg);
-        _punchItemInProjectB = new PunchItem(TestPlantA, _projectB, Guid.NewGuid(), "B", _raisedByOrg, _clearingByOrg);
+        var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
+        var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
+
+        _punchItemInProjectA = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "A", raisedByOrg, clearingByOrg);
+        _punchItemInProjectB = new PunchItem(TestPlantA, _projectB, Guid.NewGuid(), "B", raisedByOrg, clearingByOrg);
 
         context.PunchItems.Add(_punchItemInProjectA);
         context.PunchItems.Add(_punchItemInProjectB);

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
@@ -18,11 +18,11 @@ public abstract class ReadOnlyTestsBase : TestsBase
     protected Project _projectB;
     protected Project _closedProjectC;
     protected Person _currentPerson;
-    protected LibraryItem _raisedByOrg;
-    protected LibraryItem _clearingByOrg;
-    protected LibraryItem _priority;
-    protected LibraryItem _sorting;
-    protected LibraryItem _type;
+    protected int _raisedByOrgId;
+    protected int _clearingByOrgId;
+    protected int _priorityId;
+    protected int _sortingId;
+    protected int _typeId;
     protected readonly Guid CurrentUserOid = new ("12345678-1234-1234-1234-123456789123");
     protected DbContextOptions<CompletionContext> _dbContextOptions;
     protected IPlantProvider _plantProviderMockObject;
@@ -62,42 +62,42 @@ public abstract class ReadOnlyTestsBase : TestsBase
         AddProject(context, _projectB);
         AddProject(context, _closedProjectC);
 
-        _raisedByOrg = new LibraryItem(
+        var raisedByOrg = new LibraryItem(
             TestPlantA,
             Guid.NewGuid(), 
             "COM",
             "COM desc",
             LibraryType.COMPLETION_ORGANIZATION);
-        _clearingByOrg = new LibraryItem(
+        var clearingByOrg = new LibraryItem(
             TestPlantA,
             Guid.NewGuid(),
             "ENG",
             "ENG desc",
             LibraryType.COMPLETION_ORGANIZATION);
-        _priority = new LibraryItem(
+        var priority = new LibraryItem(
             TestPlantA,
             Guid.NewGuid(),
             "P1",
             "P1 desc",
             LibraryType.PUNCHLIST_PRIORITY);
-        _sorting = new LibraryItem(
+        var sorting = new LibraryItem(
             TestPlantA,
             Guid.NewGuid(),
             "A",
             "A desc",
             LibraryType.PUNCHLIST_SORTING);
-        _type = new LibraryItem(
+        var type = new LibraryItem(
             TestPlantA,
             Guid.NewGuid(),
             "Paint",
             "Paint desc",
             LibraryType.PUNCHLIST_TYPE);
 
-        AddLibraryItem(context, _raisedByOrg);
-        AddLibraryItem(context, _clearingByOrg);
-        AddLibraryItem(context, _priority);
-        AddLibraryItem(context, _sorting);
-        AddLibraryItem(context, _type);
+        _raisedByOrgId = AddLibraryItem(context, raisedByOrg);
+        _clearingByOrgId = AddLibraryItem(context, clearingByOrg);
+        _priorityId = AddLibraryItem(context, priority);
+        _sortingId = AddLibraryItem(context, sorting);
+        _typeId = AddLibraryItem(context, type);
 
         SetupNewDatabase(_dbContextOptions);
     }
@@ -124,10 +124,10 @@ public abstract class ReadOnlyTestsBase : TestsBase
         return project;
     }
 
-    protected LibraryItem AddLibraryItem(CompletionContext context, LibraryItem libraryItem)
+    protected int AddLibraryItem(CompletionContext context, LibraryItem libraryItem)
     {
         context.Library.Add(libraryItem);
         context.SaveChangesAsync().Wait();
-        return libraryItem;
+        return libraryItem.Id;
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/ReadOnlyTestsBase.cs
@@ -14,9 +14,9 @@ namespace Equinor.ProCoSys.Completion.Test.Common;
 
 public abstract class ReadOnlyTestsBase : TestsBase
 {
-    protected Project _projectA;
-    protected Project _projectB;
-    protected Project _closedProjectC;
+    protected int _projectAId;
+    protected int _projectBId;
+    protected int _closedProjectCId;
     protected Person _currentPerson;
     protected int _raisedByOrgId;
     protected int _clearingByOrgId;
@@ -54,13 +54,13 @@ public abstract class ReadOnlyTestsBase : TestsBase
             AddPerson(context, _currentPerson);
         }
 
-        _projectA = new(TestPlantA, Guid.NewGuid(), "ProA", "ProA desc");
-        _projectB = new(TestPlantA, Guid.NewGuid(), "ProB", "ProB desc");
-        _closedProjectC = new(TestPlantA, Guid.NewGuid(), "ProC", "ProC desc") {IsClosed = true};
+        var projectA = new Project(TestPlantA, Guid.NewGuid(), "ProA", "ProA desc");
+        var projectB = new Project(TestPlantA, Guid.NewGuid(), "ProB", "ProB desc");
+        var closedProjectC = new Project(TestPlantA, Guid.NewGuid(), "ProC", "ProC desc") {IsClosed = true};
 
-        AddProject(context, _projectA);
-        AddProject(context, _projectB);
-        AddProject(context, _closedProjectC);
+        _projectAId = AddProject(context, projectA);
+        _projectBId = AddProject(context, projectB);
+        _closedProjectCId = AddProject(context, closedProjectC);
 
         var raisedByOrg = new LibraryItem(
             TestPlantA,
@@ -117,11 +117,11 @@ public abstract class ReadOnlyTestsBase : TestsBase
         return person;
     }
 
-    protected Project AddProject(CompletionContext context, Project project)
+    protected int AddProject(CompletionContext context, Project project)
     {
         context.Projects.Add(project);
         context.SaveChangesAsync().Wait();
-        return project;
+        return project.Id;
     }
 
     protected int AddLibraryItem(CompletionContext context, LibraryItem libraryItem)

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure;
@@ -18,11 +19,14 @@ public class PunchItemHelperTests : ReadOnlyTestsBase
     protected override void SetupNewDatabase(DbContextOptions<CompletionContext> dbContextOptions)
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
-                
+
+        var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
+        var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
+
         // Save to get real id on project
         context.SaveChangesAsync().Wait();
 
-        var punchItem = new PunchItem(TestPlantA, _projectA, _checkListGuid, "Title", _raisedByOrg, _clearingByOrg);
+        var punchItem = new PunchItem(TestPlantA, _projectA, _checkListGuid, "Title", raisedByOrg, clearingByOrg);
         context.PunchItems.Add(punchItem);
         context.SaveChangesAsync().Wait();
         _punchItemGuid = punchItem.Guid;

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Misc/PunchItemHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Infrastructure;
 using Equinor.ProCoSys.Completion.Test.Common;
@@ -15,11 +16,13 @@ public class PunchItemHelperTests : ReadOnlyTestsBase
 {
     private Guid _punchItemGuid;
     private readonly Guid _checkListGuid = Guid.NewGuid();
+    private Project _projectA = null!;
 
     protected override void SetupNewDatabase(DbContextOptions<CompletionContext> dbContextOptions)
     {
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
+        _projectA = context.Projects.Single(p => p.Id == _projectAId);
         var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
         var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
 

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Validators/PunchItemValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Validators/PunchItemValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.Validators;
 using Equinor.ProCoSys.Completion.Infrastructure;
@@ -21,12 +22,17 @@ public class PunchItemValidatorTests : ReadOnlyTestsBase
     private PunchItem _clearedButNotVerifiedPunchItem = null!;
     private PunchItem _verifiedPunchItem = null!;
     private ICheckListValidator _checkListValidatorMock = null!;
+    private Project _projectA = null!;
+    private Project _closedProjectC = null!;
 
     protected override void SetupNewDatabase(DbContextOptions<CompletionContext> dbContextOptions)
     {
         _checkListValidatorMock = Substitute.For<ICheckListValidator>();
 
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
+
+        _projectA = context.Projects.Single(p => p.Id == _projectAId);
+        _closedProjectC = context.Projects.Single(p => p.Id == _closedProjectCId);
 
         var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
         var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Validators/PunchItemValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.Tests/Validators/PunchItemValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.Validators;
@@ -27,12 +28,15 @@ public class PunchItemValidatorTests : ReadOnlyTestsBase
 
         using var context = new CompletionContext(dbContextOptions, _plantProviderMockObject, _eventDispatcherMockObject, _currentUserProviderMockObject);
 
-        _punchItemInOpenProject = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x1", _raisedByOrg, _clearingByOrg);
-        _punchItemInClosedProject = new PunchItem(TestPlantA, _closedProjectC, Guid.NewGuid(), "x2", _raisedByOrg, _clearingByOrg);
+        var raisedByOrg = context.Library.Single(l => l.Id == _raisedByOrgId);
+        var clearingByOrg = context.Library.Single(l => l.Id == _clearingByOrgId);
+
+        _punchItemInOpenProject = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x1", raisedByOrg, clearingByOrg);
+        _punchItemInClosedProject = new PunchItem(TestPlantA, _closedProjectC, Guid.NewGuid(), "x2", raisedByOrg, clearingByOrg);
         _notClearedPunchItem = _punchItemInOpenProject;
-        _clearedButNotVerifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x3", _raisedByOrg, _clearingByOrg);
+        _clearedButNotVerifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x3", raisedByOrg, clearingByOrg);
         _clearedButNotVerifiedPunchItem.Clear(_currentPerson);
-        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x4", _raisedByOrg, _clearingByOrg);
+        _verifiedPunchItem = new PunchItem(TestPlantA, _projectA, Guid.NewGuid(), "x4", raisedByOrg, clearingByOrg);
         _verifiedPunchItem.Clear(_currentPerson);
         _verifiedPunchItem.Verify(_currentPerson);
 


### PR DESCRIPTION
[AB#104046](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/104046)

The motivation for this change is to have navigation properties from PunchItem to other entities (as LibraryItem, Project) for 2 reasons:
1) When getting Punch from DB vi can use .Include in EF to get related entities
1) In handlers for integration events, where we want to send info to the bus, we can send the updated PunchItem, inclusive related entities, to the handler

Yet a PR will come, where we also have navigation properties from PunchItem to Person entities (created by, modified by, cleared by, etc.)