### PR TITLE
104172 - Use MassTransit.NewId.NextGuid() to create Guids

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/AttachmentAggregate/Attachment.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/AttachmentAggregate/Attachment.cs
@@ -24,7 +24,7 @@ public class Attachment : EntityBase, IAggregateRoot, ICreationAuditable, IModif
         SourceType = sourceType;
         SourceGuid = sourceGuid;
         FileName = fileName;
-        Guid = Guid.NewGuid();
+        Guid = MassTransit.NewId.NextGuid();
         if (plant.Length < 5)
         {
             throw new ArgumentException($"{nameof(plant)} must have minimum length 5");

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/CommentAggregate/Comment.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/CommentAggregate/Comment.cs
@@ -16,7 +16,7 @@ public class Comment : EntityBase, IAggregateRoot, ICreationAuditable, IBelongTo
         SourceType = sourceType;
         SourceGuid = sourceGuid;
         Text = text;
-        Guid = Guid.NewGuid();
+        Guid = MassTransit.NewId.NextGuid();
     }
 
     // private setters needed for Entity Framework

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/LinkAggregate/Link.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/LinkAggregate/Link.cs
@@ -18,7 +18,7 @@ public class Link : EntityBase, IAggregateRoot, ICreationAuditable, IModificatio
         SourceGuid = sourceGuid;
         Title = title;
         Url = url;
-        Guid = Guid.NewGuid();
+        Guid = MassTransit.NewId.NextGuid();
     }
 
     // private setters needed for Entity Framework

--- a/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/AggregateModels/PunchItemAggregate/PunchItem.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
-using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
-using Equinor.ProCoSys.Completion.Domain.Audit;
-using Equinor.ProCoSys.Common.Time;
 using Equinor.ProCoSys.Common;
+using Equinor.ProCoSys.Common.Time;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.DocumentAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.LibraryAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.SWCRAggregate;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.WorkOrderAggregate;
+using Equinor.ProCoSys.Completion.Domain.Audit;
 
 namespace Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 
@@ -39,7 +39,7 @@ public class PunchItem : PlantEntityBase, IAggregateRoot, ICreationAuditable, IM
         CheckListGuid = checkListGuid;
         Category = category;
         Description = description;
-        Guid = Guid.NewGuid();
+        Guid = MassTransit.NewId.NextGuid();
 
         SetProject(plant, project);
         SetRaisedByOrg(raisedByOrg);

--- a/src/Equinor.ProCoSys.Completion.Domain/Equinor.ProCoSys.Completion.Domain.csproj
+++ b/src/Equinor.ProCoSys.Completion.Domain/Equinor.ProCoSys.Completion.Domain.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Equinor.ProCoSys.Common" Version="1.0.15" />
+    <PackageReference Include="MassTransit.Abstractions" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This to prevent index fragmentation in DB tables

[AB#104172](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/104172)