### PR TITLE
109354 history properties in create punch

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -204,7 +204,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
     private void SetEstimate(PunchItem punchItem, int? estimate, List<IProperty> properties)
     {
         punchItem.Estimate = estimate;
-        if (!estimate.HasValue)
+        if (estimate is null)
         {
             return;
         }
@@ -213,7 +213,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
 
     private void SetDueTime(PunchItem punchItem, DateTime? dueTimeUtc, List<IProperty> properties)
     {
-        if (!dueTimeUtc.HasValue)
+        if (dueTimeUtc is null)
         {
             return;
         }
@@ -227,7 +227,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!documentGuid.HasValue)
+        if (documentGuid is null)
         {
             return;
         }
@@ -243,7 +243,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!swcrGuid.HasValue)
+        if (swcrGuid is null)
         {
             return;
         }
@@ -259,7 +259,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!originalWorkOrderGuid.HasValue)
+        if (originalWorkOrderGuid is null)
         {
             return;
         }
@@ -275,7 +275,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!workOrderGuid.HasValue)
+        if (workOrderGuid is null)
         {
             return;
         }
@@ -291,7 +291,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!actionByPersonOid.HasValue)
+        if (actionByPersonOid is null)
         {
             return;
         }
@@ -310,10 +310,11 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         List<IProperty> properties,
         CancellationToken cancellationToken)
     {
-        if (!libraryGuid.HasValue)
+        if (libraryGuid is null)
         {
             return;
         }
+
         var libraryItem = await _libraryItemRepository.GetByGuidAndTypeAsync(libraryGuid.Value, libraryType, cancellationToken);
 
         switch (libraryType)

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -125,7 +125,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
 
             await _historyEventPublisher.PublishCreatedEventAsync(
                 punchItem.Plant,
-                $"{punchItem.Category} punch item {punchItem.ItemNo} created",
+                $"Punch item {punchItem.Category} {punchItem.ItemNo} created",
                 punchItem.Guid,
                 punchItem.CheckListGuid,
                 new User(punchItem.CreatedBy.Guid, punchItem.CreatedBy.GetFullName()),

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandler.cs
@@ -58,7 +58,7 @@ public class DeletePunchItemCommandHandler : IRequestHandler<DeletePunchItemComm
             var integrationEvent = await _punchEventPublisher.PublishDeletedEventAsync(punchItem, cancellationToken);
             await _historyEventPublisher.PublishDeletedEventAsync(
                 punchItem.Plant,
-                "Punch item deleted",
+                $"Punch item {punchItem.Category} {punchItem.ItemNo} deleted",
                 punchItem.Guid,
                 punchItem.CheckListGuid,
                 new User(punchItem.ModifiedBy!.Guid, punchItem.ModifiedBy!.GetFullName()),

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/CompletionContext.cs
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/CompletionContext.cs
@@ -115,7 +115,10 @@ public class CompletionContext : DbContext, IUnitOfWork, IReadOnlyContext
     {
         var addedEntries = ChangeTracker
             .Entries<ICreationAuditable>()
-            .Where(x => x.State == EntityState.Added)
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            // CreatedBy WILL be null after newing a new entity, before using SetCreated()
+            // We want to skip entities where CreatedBy is set, since SetAuditDataAsync can be used repeatedly 
+            .Where(x => x.State == EntityState.Added && x.Entity.CreatedBy is null)
             .ToList();
         var modifiedEntries = ChangeTracker
             .Entries<IModificationAuditable>()

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/User.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/User.cs
@@ -2,4 +2,5 @@
 
 namespace Equinor.ProCoSys.Completion.MessageContracts;
 
+// todo 109355/109612 Flytt til Domain.Events.IntegrationEvents.HistoryEvents
 public record User(Guid Oid, string FullName) : IUser;

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -171,16 +171,6 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
     }
 
     [TestMethod]
-    public async Task HandlingCommand_ShouldNotSetAuditData()
-    {
-        // Act
-        await _dut.Handle(_command, default);
-
-        // Assert
-        await _unitOfWorkMock.Received(0).SetAuditDataAsync();
-    }
-
-    [TestMethod]
     public async Task HandlingCommand_ShouldSaveTwice()
     {
         // Act

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -243,7 +243,7 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         // Assert
         Assert.AreEqual(_punchItemAddedToRepository.Plant, _plantPublishedToHistory);
         Assert.AreEqual(
-            $"{_punchItemAddedToRepository.Category} punch item {_punchItemAddedToRepository.ItemNo} created", 
+            $"Punch item {_punchItemAddedToRepository.Category} {_punchItemAddedToRepository.ItemNo} created", 
             _displayNamePublishedToHistory);
         Assert.AreEqual(_punchItemAddedToRepository.Guid, _guidPublishedToHistory);
         Assert.AreEqual(_punchItemAddedToRepository.CheckListGuid, _parentGuidPublishedToHistory);

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.CreatePunchItem;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
-using Equinor.ProCoSys.Completion.MessageContracts;
 using Equinor.ProCoSys.Completion.MessageContracts.History;
 using Equinor.ProCoSys.Completion.MessageContracts.PunchItem;
+using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
+using User = Equinor.ProCoSys.Completion.MessageContracts.User;
 
 namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.CreatePunchItem;
 
@@ -18,6 +20,7 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
     private readonly string _testPlant = TestPlantA;
     private readonly Guid _existingCheckListGuid = Guid.NewGuid();
     private PunchItem _punchItemAddedToRepository;
+    private readonly int _punchItemId = 17;
 
     private CreatePunchItemCommandHandler _dut;
     private CreatePunchItemCommand _command;
@@ -33,11 +36,12 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             });
 
         _unitOfWorkMock
-            .When(x => x.SetAuditDataAsync())
-            .Do(_ =>
+            .When(x => x.SaveChangesAsync())
+            .Do(Callback.First(_ =>
             {
                 _punchItemAddedToRepository.SetCreated(_currentPerson);
-            });
+                _punchItemAddedToRepository.SetProtectedIdForTesting(_punchItemId);
+            }));
 
         _command = new CreatePunchItemCommand(
             Category.PA,
@@ -167,23 +171,23 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
     }
 
     [TestMethod]
-    public async Task HandlingCommand_ShouldSetAuditData()
+    public async Task HandlingCommand_ShouldNotSetAuditData()
     {
         // Act
         await _dut.Handle(_command, default);
 
         // Assert
-        await _unitOfWorkMock.Received(1).SetAuditDataAsync();
+        await _unitOfWorkMock.Received(0).SetAuditDataAsync();
     }
 
     [TestMethod]
-    public async Task HandlingCommand_ShouldSave()
+    public async Task HandlingCommand_ShouldSaveTwice()
     {
         // Act
         await _dut.Handle(_command, default);
 
         // Assert
-        await _unitOfWorkMock.Received(1).SaveChangesAsync();
+        await _unitOfWorkMock.Received(2).SaveChangesAsync();
     }
 
     [TestMethod]
@@ -231,22 +235,173 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
     }
 
     [TestMethod]
-    public async Task HandlingCommand_ShouldPublishCorrectHistoryEvent()
+    public async Task HandlingCommand_WithAllPropertiesSet_ShouldPublishCorrectHistoryEvent()
     {
         // Act
         await _dut.Handle(_command, default);
 
         // Assert
         Assert.AreEqual(_punchItemAddedToRepository.Plant, _plantPublishedToHistory);
-        Assert.AreEqual("Punch item created", _displayNamePublishedToHistory);
+        Assert.AreEqual(
+            $"{_punchItemAddedToRepository.Category} punch item {_punchItemAddedToRepository.ItemNo} created", 
+            _displayNamePublishedToHistory);
         Assert.AreEqual(_punchItemAddedToRepository.Guid, _guidPublishedToHistory);
         Assert.AreEqual(_punchItemAddedToRepository.CheckListGuid, _parentGuidPublishedToHistory);
         Assert.IsNotNull(_userPublishedToHistory);
         Assert.AreEqual(_punchItemAddedToRepository.CreatedBy.Guid, _userPublishedToHistory.Oid);
         Assert.AreEqual(_punchItemAddedToRepository.CreatedBy.GetFullName(), _userPublishedToHistory.FullName);
         Assert.AreEqual(_punchItemAddedToRepository.CreatedAtUtc, _dateTimePublishedToHistory);
-        Assert.IsNotNull(_newPropertiesPublishedToHistory);
-        // todo 109354 test published properties to history
-        Assert.AreEqual(0, _newPropertiesPublishedToHistory.Count);
+        Assert.IsNotNull(_propertiesPublishedToHistory);
+
+        Assert.AreEqual(19, _propertiesPublishedToHistory.Count);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ItemNo)),
+            _punchItemAddedToRepository.ItemNo);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Category)),
+            _punchItemAddedToRepository.Category.ToString());
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Description)),
+            _punchItemAddedToRepository.Description);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.RaisedByOrg)),
+            _punchItemAddedToRepository.RaisedByOrg.Code);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ClearingByOrg)),
+            _punchItemAddedToRepository.ClearingByOrg.Code);
+        AssertPerson(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ActionBy)),
+            new User(_existingPerson1.Guid, _existingPerson1.GetFullName()));
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.DueTimeUtc)),
+            _punchItemAddedToRepository.DueTimeUtc);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Priority)),
+            _punchItemAddedToRepository.Priority!.Code);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Sorting)),
+            _punchItemAddedToRepository.Sorting!.Code);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Type)),
+            _punchItemAddedToRepository.Type!.Code);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Estimate)),
+            _punchItemAddedToRepository.Estimate!.Value);
+
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Document)),
+            _punchItemAddedToRepository.Document!.No);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.SWCR)),
+            _punchItemAddedToRepository.SWCR!.No);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.OriginalWorkOrder)),
+            _punchItemAddedToRepository.OriginalWorkOrder!.No);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.WorkOrder)),
+            _punchItemAddedToRepository.WorkOrder!.No);
+
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ExternalItemNo)),
+            _punchItemAddedToRepository.ExternalItemNo);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialRequired)),
+            _punchItemAddedToRepository.MaterialRequired);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialETAUtc)),
+            _punchItemAddedToRepository.MaterialETAUtc!.Value);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialExternalNo)),
+            _punchItemAddedToRepository.MaterialExternalNo);
+    }
+
+    [TestMethod]
+    public async Task HandlingCommand_WithOnlyRequiredPropertiesSet_ShouldPublishCorrectHistoryEvent()
+    {
+        // Arrange
+        var command = new CreatePunchItemCommand(
+            Category.PA,
+            "P123",
+            _existingProject[_testPlant].Guid,
+            _existingCheckListGuid,
+            _existingRaisedByOrg1[_testPlant].Guid,
+            _existingClearingByOrg1[_testPlant].Guid,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            null,
+            null);
+
+        // Act
+        await _dut.Handle(command, default);
+
+        // Assert
+        Assert.IsNotNull(_propertiesPublishedToHistory);
+
+        Assert.AreEqual(5, _propertiesPublishedToHistory.Count);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ItemNo)),
+            _punchItemAddedToRepository.ItemNo);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Category)),
+            _punchItemAddedToRepository.Category.ToString());
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.Description)),
+            _punchItemAddedToRepository.Description);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.RaisedByOrg)),
+            _punchItemAddedToRepository.RaisedByOrg.Code);
+        AssertProperty(
+            _propertiesPublishedToHistory
+                .SingleOrDefault(c => c.Name == nameof(PunchItem.ClearingByOrg)),
+            _punchItemAddedToRepository.ClearingByOrg.Code);
+    }
+
+    private void AssertPerson(IProperty property, User value)
+    {
+        Assert.IsNotNull(property);
+        var user = property.Value as User;
+        Assert.IsNotNull(user);
+        Assert.AreEqual(value.Oid, user.Oid);
+        Assert.AreEqual(value.FullName, user.FullName);
+    }
+
+    private void AssertProperty(IProperty property, object value)
+    {
+        Assert.IsNotNull(property);
+        Assert.IsNotNull(value);
+        Assert.AreEqual(value, property.Value);
     }
 }

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.Command.PunchItemCommands.DeletePunchItem;
+using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.MessageContracts;
 using Equinor.ProCoSys.Completion.MessageContracts.PunchItem;
 using Microsoft.Extensions.Logging;
@@ -127,7 +128,9 @@ namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands.DeletePunc
 
             // Assert
             Assert.AreEqual(_existingPunchItem[_testPlant].Plant, _plantPublishedToHistory);
-            Assert.AreEqual("Punch item deleted", _displayNamePublishedToHistory);
+            Assert.AreEqual(
+                $"Punch item {_existingPunchItem[_testPlant].Category} {_existingPunchItem[_testPlant].ItemNo} deleted", 
+                _displayNamePublishedToHistory);
             Assert.AreEqual(_existingPunchItem[_testPlant].Guid, _guidPublishedToHistory);
             Assert.AreEqual(_existingPunchItem[_testPlant].CheckListGuid, _parentGuidPublishedToHistory);
             Assert.IsNotNull(_userPublishedToHistory);

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/PunchItemCommandHandlerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/PunchItemCommandHandlerTestsBase.cs
@@ -42,7 +42,7 @@ namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands
         protected Guid? _parentGuidPublishedToHistory;
         protected User _userPublishedToHistory;
         protected DateTime _dateTimePublishedToHistory;
-        protected List<IProperty> _newPropertiesPublishedToHistory;
+        protected List<IProperty> _propertiesPublishedToHistory;
         protected List<IChangedProperty> _changedPropertiesPublishedToHistory;
 
         protected Dictionary<string, Project> _existingProject = new();
@@ -97,7 +97,7 @@ namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands
                     _parentGuidPublishedToHistory = info.Arg<Guid?>();
                     _userPublishedToHistory = info.Arg<User>();
                     _dateTimePublishedToHistory = info.Arg<DateTime>();
-                    _newPropertiesPublishedToHistory = info.Arg<List<IProperty>>();
+                    _propertiesPublishedToHistory = info.Arg<List<IProperty>>();
                 });
 
             _historyEventPublisherMock
@@ -210,7 +210,7 @@ namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands
 
         private Document SetupDocument(string plant, int id)
         {
-            var document = new Document(plant, Guid.NewGuid(), null!);
+            var document = new Document(plant, Guid.NewGuid(), Guid.NewGuid().ToString());
             document.SetProtectedIdForTesting(++id);
 
             _documentRepositoryMock
@@ -233,7 +233,7 @@ namespace Equinor.ProCoSys.Completion.Command.Tests.PunchItemCommands
 
         private WorkOrder SetupWorkOrder(string plant, int id)
         {
-            var workOrder = new WorkOrder(plant, Guid.NewGuid(), null!);
+            var workOrder = new WorkOrder(plant, Guid.NewGuid(), Guid.NewGuid().ToString());
             workOrder.SetProtectedIdForTesting(id);
             _workOrderRepositoryMock
                 .GetAsync(workOrder.Guid, default)


### PR DESCRIPTION
[AB#109354](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/109354)

Main purpose of PR is to fill in properties in a published history create event when creating a punch.
Also added better format of display name of create and delete history event to contain category + ItemNo. This because we will probably show these events in context of the parent checklist. Dispalyname as "Punch item created" will have less meaning in such context since there will exists many creates and deletes