### PR TITLE
110024 history contract improvements

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
@@ -293,7 +293,7 @@ public class AttachmentService : IAttachmentService
         var changes = new List<IChangedProperty>();
         var oldRevision = attachment.RevisionNumber;
         attachment.IncreaseRevisionNumber();
-        changes.Add(new ChangedProperty<int>(nameof(Attachment.RevisionNumber), oldRevision, attachment.RevisionNumber));
+        changes.Add(new ChangedProperty<int>(nameof(Attachment.RevisionNumber), oldRevision, attachment.RevisionNumber, ValueDisplayType.IntAsText));
         return changes;
     }
 }

--- a/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
@@ -260,6 +260,7 @@ public class AttachmentService : IAttachmentService
         var historyEvent = new HistoryUpdatedIntegrationEvent(
             displayName,
             attachment.Guid,
+            attachment.ParentGuid,
             new User(attachment.ModifiedBy!.Guid, attachment.ModifiedBy!.GetFullName()),
             attachment.ModifiedAtUtc!.Value,
             changes);

--- a/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/Attachments/AttachmentService.cs
@@ -235,7 +235,6 @@ public class AttachmentService : IAttachmentService
             new Property(nameof(Attachment.FileName), attachment.FileName)
         };
         var historyEvent = new HistoryCreatedIntegrationEvent(
-            _plantProvider.Plant,
             $"Attachment {attachment.FileName} uploaded",
             attachment.Guid,
             attachment.ParentGuid,
@@ -259,7 +258,6 @@ public class AttachmentService : IAttachmentService
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryUpdatedIntegrationEvent(
-            _plantProvider.Plant,
             displayName,
             attachment.Guid,
             new User(attachment.ModifiedBy!.Guid, attachment.ModifiedBy!.GetFullName()),
@@ -278,7 +276,6 @@ public class AttachmentService : IAttachmentService
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryDeletedIntegrationEvent(
-            _plantProvider.Plant,
             $"Attachment {attachment.FileName} deleted",
             attachment.Guid,
             attachment.ParentGuid,

--- a/src/Equinor.ProCoSys.Completion.Command/Links/LinkService.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/Links/LinkService.cs
@@ -142,7 +142,6 @@ public class LinkService : ILinkService
             new Property(nameof(Link.Url), link.Url)
         };
         var historyEvent = new HistoryCreatedIntegrationEvent(
-        _plantProvider.Plant,
             $"Link {link.Title} created",
             link.Guid,
             link.ParentGuid,
@@ -165,7 +164,6 @@ public class LinkService : ILinkService
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryUpdatedIntegrationEvent(
-        _plantProvider.Plant,
             $"Link {link.Title} updated",
             link.Guid,
             new User(link.ModifiedBy!.Guid, link.ModifiedBy!.GetFullName()),
@@ -184,7 +182,6 @@ public class LinkService : ILinkService
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryDeletedIntegrationEvent(
-            _plantProvider.Plant,
             $"Link {link.Title} deleted",
             link.Guid,
             link.ParentGuid,

--- a/src/Equinor.ProCoSys.Completion.Command/Links/LinkService.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/Links/LinkService.cs
@@ -166,6 +166,7 @@ public class LinkService : ILinkService
         var historyEvent = new HistoryUpdatedIntegrationEvent(
             $"Link {link.Title} updated",
             link.Guid,
+            link.ParentGuid,
             new User(link.ModifiedBy!.Guid, link.ModifiedBy!.GetFullName()),
             link.ModifiedAtUtc!.Value,
             changes);

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -147,7 +147,6 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryCreatedIntegrationEvent(
-            punchItem.Plant,
             $"Punch item {punchItem.Category} {punchItem.ItemNo} created",
             punchItem.Guid,
             punchItem.CheckListGuid,

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandler.cs
@@ -116,7 +116,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             // Add property for ItemNo first in list, since it is an "important" property
-            properties.Insert(0, new Property(nameof(PunchItem.ItemNo), punchItem.ItemNo));
+            properties.Insert(0, new Property(nameof(PunchItem.ItemNo), punchItem.ItemNo, ValueDisplayType.IntAsText));
 
             var integrationEvent = await PublishPunchItemCreatedIntegrationEventsAsync(punchItem, properties, cancellationToken);
 
@@ -184,7 +184,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
             return;
         }
         punchItem.MaterialETAUtc = materialETAUtc;
-        properties.Add(new Property(nameof(PunchItem.MaterialETAUtc), punchItem.MaterialETAUtc));
+        properties.Add(new Property(nameof(PunchItem.MaterialETAUtc), punchItem.MaterialETAUtc, ValueDisplayType.DateTimeAsDateOnly));
     }
 
     private void SetMaterialRequired(PunchItem punchItem, bool materialRequired, List<IProperty> properties)
@@ -194,7 +194,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
             return;
         }
         punchItem.MaterialRequired = materialRequired;
-        properties.Add(new Property(nameof(PunchItem.MaterialRequired), punchItem.MaterialRequired));
+        properties.Add(new Property(nameof(PunchItem.MaterialRequired), punchItem.MaterialRequired, ValueDisplayType.BoolAsYesNo));
     }
 
     private void SetExternalItemNo(PunchItem punchItem, string? externalItemNo, List<IProperty> properties)
@@ -214,7 +214,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         {
             return;
         }
-        properties.Add(new Property(nameof(PunchItem.Estimate), estimate.Value));
+        properties.Add(new Property(nameof(PunchItem.Estimate), estimate.Value, ValueDisplayType.IntAsText));
     }
 
     private void SetDueTime(PunchItem punchItem, DateTime? dueTimeUtc, List<IProperty> properties)
@@ -224,7 +224,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
             return;
         }
         punchItem.DueTimeUtc = dueTimeUtc;
-        properties.Add(new Property(nameof(PunchItem.DueTimeUtc), punchItem.DueTimeUtc.Value));
+        properties.Add(new Property(nameof(PunchItem.DueTimeUtc), punchItem.DueTimeUtc.Value, ValueDisplayType.DateTimeAsDateOnly));
     }
 
     private async Task SetDocumentAsync(
@@ -256,7 +256,7 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
 
         var swcr = await _swcrRepository.GetAsync(swcrGuid.Value, cancellationToken);
         punchItem.SetSWCR(swcr);
-        properties.Add(new Property(nameof(PunchItem.SWCR), punchItem.SWCR!.No));
+        properties.Add(new Property(nameof(PunchItem.SWCR), punchItem.SWCR!.No, ValueDisplayType.IntAsText));
     }
 
     private async Task SetOriginalWorkOrderAsync(
@@ -306,7 +306,8 @@ public class CreatePunchItemCommandHandler : IRequestHandler<CreatePunchItemComm
         punchItem.SetActionBy(person);
         properties.Add(new Property(
             nameof(PunchItem.ActionBy),
-            new User(punchItem.ActionBy!.Guid, punchItem.ActionBy!.GetFullName())));
+            new User(punchItem.ActionBy!.Guid, punchItem.ActionBy!.GetFullName()),
+            ValueDisplayType.UserAsNameOnly));
     }
 
     private async Task SetLibraryItemAsync(

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/DeletePunchItem/DeletePunchItemCommandHandler.cs
@@ -81,7 +81,6 @@ public class DeletePunchItemCommandHandler : IRequestHandler<DeletePunchItemComm
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryDeletedIntegrationEvent(
-            punchItem.Plant,
             $"Punch item {punchItem.Category} {punchItem.ItemNo} deleted",
             punchItem.Guid,
             punchItem.CheckListGuid,

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/PunchUpdateCommandBase.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/PunchUpdateCommandBase.cs
@@ -23,7 +23,6 @@ public abstract class PunchUpdateCommandBase
         await integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);
 
         var historyEvent = new HistoryUpdatedIntegrationEvent(
-            punchItem.Plant,
             historyDisplayName,
             punchItem.Guid,
             new User(punchItem.ModifiedBy!.Guid, punchItem.ModifiedBy!.GetFullName()),

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/PunchUpdateCommandBase.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/PunchUpdateCommandBase.cs
@@ -25,6 +25,10 @@ public abstract class PunchUpdateCommandBase
         var historyEvent = new HistoryUpdatedIntegrationEvent(
             historyDisplayName,
             punchItem.Guid,
+            // a checklist is parent of the punch. Setting null for parent here, will cause that
+            // punch updates will not be shown in checklist history. For now we assume that
+            // creation and deletion of punch are sufficient in checklist history
+            null,
             new User(punchItem.ModifiedBy!.Guid, punchItem.ModifiedBy!.GetFullName()),
             punchItem.ModifiedAtUtc!.Value,
             changedProperties);

--- a/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Completion.Command/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandler.cs
@@ -277,14 +277,16 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
             var swcr = await _swcrRepository.GetAsync(patchedPunchItem.SWCRGuid.Value, cancellationToken);
             changes.Add(new ChangedProperty<int?>(nameof(punchItem.SWCR),
                 punchItem.SWCR?.No,
-                swcr.No));
+                swcr.No,
+                ValueDisplayType.IntAsText));
             punchItem.SetSWCR(swcr);
         }
         else
         {
             changes.Add(new ChangedProperty<int?>(nameof(punchItem.SWCR),
                 punchItem.SWCR?.No,
-                null));
+                null,
+                ValueDisplayType.IntAsText));
             punchItem.ClearSWCR();
         }
     }
@@ -333,14 +335,16 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
             var person = await _personRepository.GetOrCreateAsync(patchedPunchItem.ActionByPersonOid.Value, cancellationToken);
             changes.Add(new ChangedProperty<User?>(nameof(punchItem.ActionBy),
                 punchItem.ActionBy is null ? null : new User(punchItem.ActionBy.Guid, punchItem.ActionBy.GetFullName()),
-                new User(person.Guid, person.GetFullName())));
+                new User(person.Guid, person.GetFullName()), 
+                ValueDisplayType.UserAsNameOnly));
             punchItem.SetActionBy(person);
         }
         else
         {
             changes.Add(new ChangedProperty<User?>(nameof(punchItem.ActionBy),
                 new User(punchItem.ActionBy!.Guid, punchItem.ActionBy!.GetFullName()),
-                null));
+                null, 
+                ValueDisplayType.UserAsNameOnly));
             punchItem.ClearActionBy();
         }
     }
@@ -502,7 +506,8 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
 
         changes.Add(new ChangedProperty<DateTime?>(nameof(punchItem.DueTimeUtc),
             punchItem.DueTimeUtc,
-            patchedPunchItem.DueTimeUtc));
+            patchedPunchItem.DueTimeUtc, 
+            ValueDisplayType.DateTimeAsDateOnly));
         punchItem.DueTimeUtc = patchedPunchItem.DueTimeUtc;
     }
 
@@ -515,7 +520,8 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
 
         changes.Add(new ChangedProperty<int?>(nameof(punchItem.Estimate),
             punchItem.Estimate,
-            patchedPunchItem.Estimate));
+            patchedPunchItem.Estimate, 
+            ValueDisplayType.IntAsText));
         punchItem.Estimate = patchedPunchItem.Estimate;
     }
 
@@ -541,7 +547,8 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
 
         changes.Add(new ChangedProperty<bool>(nameof(punchItem.MaterialRequired),
             punchItem.MaterialRequired,
-            patchedPunchItem.MaterialRequired));
+            patchedPunchItem.MaterialRequired,
+            ValueDisplayType.BoolAsYesNo));
         punchItem.MaterialRequired = patchedPunchItem.MaterialRequired;
     }
 
@@ -554,7 +561,8 @@ public class UpdatePunchItemCommandHandler : PunchUpdateCommandBase, IRequestHan
 
         changes.Add(new ChangedProperty<DateTime?>(nameof(punchItem.MaterialETAUtc),
             punchItem.MaterialETAUtc,
-            patchedPunchItem.MaterialETAUtc));
+            patchedPunchItem.MaterialETAUtc,
+            ValueDisplayType.DateTimeAsDateOnly));
         punchItem.MaterialETAUtc = patchedPunchItem.MaterialETAUtc;
     }
 

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/ChangedProperty.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/ChangedProperty.cs
@@ -3,7 +3,11 @@
 namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 
 // the generic param T is to force same type for OldValue and NewValue
-public record ChangedProperty<T>(string Name, T? OldValue, T? NewValue) : IChangedProperty
+public record ChangedProperty<T>(
+    string Name,
+    T? OldValue,
+    T? NewValue,
+    ValueDisplayType ValueDisplayType = ValueDisplayType.StringAsText) : IChangedProperty
 {
     object? IChangedProperty.OldValue => OldValue;
     object? IChangedProperty.NewValue => NewValue;

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryCreatedIntegrationEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryCreatedIntegrationEvent.cs
@@ -6,7 +6,6 @@ using Equinor.ProCoSys.Completion.MessageContracts.History;
 namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 
 public record HistoryCreatedIntegrationEvent(
-    string Plant,
     string DisplayName,
     Guid Guid,
     Guid? ParentGuid,

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryDeletedIntegrationEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryDeletedIntegrationEvent.cs
@@ -5,7 +5,6 @@ using Equinor.ProCoSys.Completion.MessageContracts.History;
 namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 
 public record HistoryDeletedIntegrationEvent(
-    string Plant,
     string DisplayName,
     Guid Guid,
     Guid? ParentGuid,

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryUpdatedIntegrationEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryUpdatedIntegrationEvent.cs
@@ -8,6 +8,7 @@ namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEve
 public record HistoryUpdatedIntegrationEvent(
     string DisplayName,
     Guid Guid,
+    Guid? ParentGuid,
     User EventBy,
     DateTime EventAtUtc,
     List<IChangedProperty> ChangedProperties) : IHistoryItemUpdatedV1;

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryUpdatedIntegrationEvent.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/HistoryUpdatedIntegrationEvent.cs
@@ -6,7 +6,6 @@ using Equinor.ProCoSys.Completion.MessageContracts.History;
 namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 
 public record HistoryUpdatedIntegrationEvent(
-    string Plant,
     string DisplayName,
     Guid Guid,
     User EventBy,

--- a/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/Property.cs
+++ b/src/Equinor.ProCoSys.Completion.Domain/Events/IntegrationEvents/HistoryEvents/Property.cs
@@ -2,4 +2,8 @@
 
 namespace Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 
-public record Property(string Name, object? Value) : IProperty;
+public record Property(
+    string Name, 
+    object? Value, 
+    ValueDisplayType ValueDisplayType = ValueDisplayType.StringAsText)
+    : IProperty;

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IChangedProperty.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IChangedProperty.cs
@@ -5,4 +5,5 @@ public interface IChangedProperty
     string Name { get; }
     object? OldValue { get; }
     object? NewValue { get; }
+    ValueDisplayType ValueDisplayType { get; }
 }

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItem.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItem.cs
@@ -4,6 +4,11 @@ namespace Equinor.ProCoSys.Completion.MessageContracts.History;
 
 public interface IHistoryItem
 {
+    // Guid of the parent entity of the event (optional)
+    // Should be set if the event should be available in the History of the parent
+    // Sample: It can be appropriate that an update of an attachment is a part of
+    // the history of the parent entity
+    Guid? ParentGuid { get; }
     // A human-readable name of the published event
     string DisplayName { get; }
     User EventBy { get; }

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItem.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItem.cs
@@ -4,7 +4,6 @@ namespace Equinor.ProCoSys.Completion.MessageContracts.History;
 
 public interface IHistoryItem
 {
-    string Plant { get; }
     // A human-readable name of the published event
     string DisplayName { get; }
     User EventBy { get; }

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItemCreatedV1.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItemCreatedV1.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Equinor.ProCoSys.Completion.MessageContracts.History;
 
 public interface IHistoryItemCreatedV1 : IHistoryItem, IIntegrationEvent
 {
-    // Guid of the parent entity of the event
-    Guid? ParentGuid { get; }
     List<IProperty> Properties { get; }
 }
 

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItemDeletedV1.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IHistoryItemDeletedV1.cs
@@ -1,9 +1,3 @@
-﻿using System;
+﻿namespace Equinor.ProCoSys.Completion.MessageContracts.History;
 
-namespace Equinor.ProCoSys.Completion.MessageContracts.History;
-
-public interface IHistoryItemDeletedV1 : IHistoryItem, IIntegrationEvent
-{
-    // Guid of the parent entity of the event
-    Guid? ParentGuid { get; }
-}
+public interface IHistoryItemDeletedV1 : IHistoryItem, IIntegrationEvent;

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/IProperty.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/IProperty.cs
@@ -4,4 +4,5 @@ public interface IProperty
 {
     string Name { get; }
     object? Value { get; }
+    ValueDisplayType ValueDisplayType { get; }
 }

--- a/src/Equinor.ProCoSys.Completion.MessageContracts/History/ValueDisplayType.cs
+++ b/src/Equinor.ProCoSys.Completion.MessageContracts/History/ValueDisplayType.cs
@@ -1,0 +1,22 @@
+﻿namespace Equinor.ProCoSys.Completion.MessageContracts.History;
+
+// this enum describe both the data type of the value (int, bool, DateTime), and how it should
+// be displayed to end users
+public enum ValueDisplayType
+{
+    StringAsText,
+    DateTimeAsDateAndTime,
+    DateTimeAsDateOnly,
+    BoolAsYesNo,
+    BoolAsTrueFalse,
+    IntAsText,
+    // Serialized from IUser contract, containing Oid and FullName. Display just the FullName
+    UserAsNameOnly,
+    // Serialized from IUser contract, containing Oid and FullName. Display FullName as link to Equinor Entra
+    UserAsNameAndPicture,
+    // Serialized from IUser contract, containing Oid and FullName. Display FullName + (mini) picture from Equinor Entra
+    UserAsLinkToAddressBook,
+    // Serialized from IUser contract, containing Oid and FullName. Display FullName with Contact Card "popup"-function
+    // showing user info from Equinor Entra
+    UserAsContactCard
+}

--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ApplicationModule.cs
@@ -1,4 +1,5 @@
-﻿using Equinor.ProCoSys.Auth.Authentication;
+﻿using System.Text.Json.Serialization;
+using Equinor.ProCoSys.Auth.Authentication;
 using Equinor.ProCoSys.Auth.Authorization;
 using Equinor.ProCoSys.Auth.Client;
 using Equinor.ProCoSys.BlobStorage;
@@ -99,6 +100,7 @@ public static class ApplicationModule
                 cfg.ConfigureJsonSerializerOptions(opts =>
                 {
                     opts.Converters.Add(new OracleGuidConverter());
+                    opts.Converters.Add(new JsonStringEnumConverter());
                     return opts;
                 });
                 cfg.SubscriptionEndpoint("completion_project","project", e =>

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
@@ -340,7 +340,8 @@ public class AttachmentServiceTests : TestsBase
             _plantProviderMock.Plant,
             $"Attachment {_existingAttachment.FileName} uploaded again",
             _existingAttachment,
-            _existingAttachment);
+            _existingAttachment,
+            _existingAttachment.ParentGuid);
         Assert.AreEqual(1, historyEvent.ChangedProperties.Count);
         AssertChange(
             historyEvent.ChangedProperties
@@ -610,7 +611,8 @@ public class AttachmentServiceTests : TestsBase
             _plantProviderMock.Plant,
             $"Attachment {_existingAttachment.FileName} updated",
             _existingAttachment,
-            _existingAttachment);
+            _existingAttachment,
+            _existingAttachment.ParentGuid);
 
         Assert.AreEqual(1, historyEvent.ChangedProperties.Count);
         AssertChange(

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
@@ -13,6 +13,7 @@ using Equinor.ProCoSys.Completion.Domain.AggregateModels.LabelAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.AttachmentEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 using Equinor.ProCoSys.Completion.MessageContracts;
+using Equinor.ProCoSys.Completion.MessageContracts.History;
 using Equinor.ProCoSys.Completion.Test.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -347,7 +348,8 @@ public class AttachmentServiceTests : TestsBase
             historyEvent.ChangedProperties
                 .SingleOrDefault(c => c.Name == nameof(Attachment.RevisionNumber)),
             oldRevisionNumber,
-            _existingAttachment.RevisionNumber);
+            _existingAttachment.RevisionNumber, 
+            ValueDisplayType.IntAsText);
     }
 
     [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Attachments/AttachmentServiceTests.cs
@@ -203,7 +203,6 @@ public class AttachmentServiceTests : TestsBase
         // Assert
         AssertHistoryCreatedIntegrationEvent(
             historyEvent,
-            _plantProviderMock.Plant,
             $"Attachment {_attachmentAddedToRepository.FileName} uploaded",
             _attachmentAddedToRepository.ParentGuid,
             _attachmentAddedToRepository,

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Links/LinkServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Links/LinkServiceTests.cs
@@ -297,7 +297,8 @@ public class LinkServiceTests : TestsBase
             _plantProviderMock.Plant,
             $"Link {_existingLink.Title} updated",
             _existingLink,
-            _existingLink);
+            _existingLink,
+            _existingLink.ParentGuid);
         Assert.AreEqual(2, historyEvent.ChangedProperties.Count);
         AssertChange(
             historyEvent.ChangedProperties

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Links/LinkServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/Links/LinkServiceTests.cs
@@ -139,7 +139,6 @@ public class LinkServiceTests : TestsBase
         // Assert
         AssertHistoryCreatedIntegrationEvent(
             historyEvent,
-            _plantProviderMock.Plant,
             $"Link {_linkAddedToRepository.Title} created",
             _linkAddedToRepository.ParentGuid,
             _linkAddedToRepository,

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using Equinor.ProCoSys.Completion.DbSyncToPCS4;
 using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.PunchItemEvents;
+using Equinor.ProCoSys.Completion.MessageContracts.History;
 using Equinor.ProCoSys.Completion.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -233,7 +234,8 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.ItemNo)),
-            _punchItemAddedToRepository.ItemNo);
+            _punchItemAddedToRepository.ItemNo,
+            ValueDisplayType.IntAsText);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Category)),
@@ -257,7 +259,8 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.DueTimeUtc)),
-            _punchItemAddedToRepository.DueTimeUtc);
+            _punchItemAddedToRepository.DueTimeUtc, 
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Priority)),
@@ -273,7 +276,8 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Estimate)),
-            _punchItemAddedToRepository.Estimate!.Value);
+            _punchItemAddedToRepository.Estimate!.Value, 
+            ValueDisplayType.IntAsText);
 
         AssertProperty(
             properties
@@ -282,7 +286,8 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.SWCR)),
-            _punchItemAddedToRepository.SWCR!.No);
+            _punchItemAddedToRepository.SWCR!.No, 
+            ValueDisplayType.IntAsText);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.OriginalWorkOrder)),
@@ -299,11 +304,13 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialRequired)),
-            _punchItemAddedToRepository.MaterialRequired);
+            _punchItemAddedToRepository.MaterialRequired, 
+            ValueDisplayType.BoolAsYesNo);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialETAUtc)),
-            _punchItemAddedToRepository.MaterialETAUtc!.Value);
+            _punchItemAddedToRepository.MaterialETAUtc!.Value, 
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialExternalNo)),
@@ -362,7 +369,8 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.ItemNo)),
-            _punchItemAddedToRepository.ItemNo);
+            _punchItemAddedToRepository.ItemNo,
+            ValueDisplayType.IntAsText);
         AssertProperty(
             properties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Category)),

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/CreatePunchItem/CreatePunchItemCommandHandlerTests.cs
@@ -222,7 +222,6 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         // Assert
         AssertHistoryCreatedIntegrationEvent(
             historyEvent,
-            _punchItemAddedToRepository.Plant,
             $"Punch item {_punchItemAddedToRepository.Category} {_punchItemAddedToRepository.ItemNo} created",
             _punchItemAddedToRepository.CheckListGuid,
             _punchItemAddedToRepository,
@@ -352,7 +351,6 @@ public class CreatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
         // Assert
         AssertHistoryCreatedIntegrationEvent(
             historyEvent,
-            _punchItemAddedToRepository.Plant,
             $"Punch item {_punchItemAddedToRepository.Category} {_punchItemAddedToRepository.ItemNo} created",
             _punchItemAddedToRepository.CheckListGuid,
             _punchItemAddedToRepository,

--- a/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Command.Tests/PunchItemCommands/UpdatePunchItem/UpdatePunchItemCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Equinor.ProCoSys.Completion.Domain.AggregateModels.PunchItemAggregate;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.HistoryEvents;
 using Equinor.ProCoSys.Completion.Domain.Events.IntegrationEvents.PunchItemEvents;
 using Equinor.ProCoSys.Completion.MessageContracts;
+using Equinor.ProCoSys.Completion.MessageContracts.History;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -401,12 +402,14 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.DueTimeUtc)),
             null,
-            _newDueTimeUtc);
+            _newDueTimeUtc,
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Estimate)),
             null,
-            _newEstimate);
+            _newEstimate,
+            ValueDisplayType.IntAsText);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.OriginalWorkOrder)),
@@ -421,7 +424,8 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.SWCR)),
             null,
-            _existingSWCR1[_testPlant].No);
+            _existingSWCR1[_testPlant].No,
+            ValueDisplayType.IntAsText);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Document)),
@@ -436,12 +440,14 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialRequired)),
             oldMaterialRequired,
-            _newMaterialRequired);
+            _newMaterialRequired,
+            ValueDisplayType.BoolAsYesNo);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialETAUtc)),
             null,
-            _newMaterialETAUtc);
+            _newMaterialETAUtc, 
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialExternalNo)),
@@ -531,12 +537,14 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.DueTimeUtc)),
             _newDueTimeUtc,
-            null);
+            null,
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Estimate)),
             _newEstimate,
-            null);
+            null,
+            ValueDisplayType.IntAsText);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.OriginalWorkOrder)),
@@ -551,7 +559,8 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.SWCR)),
             _existingSWCR1[_testPlant].No,
-            null);
+            null, 
+            ValueDisplayType.IntAsText);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.Document)),
@@ -566,7 +575,8 @@ public class UpdatePunchItemCommandHandlerTests : PunchItemCommandHandlerTestsBa
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialETAUtc)),
             _newMaterialETAUtc,
-            null);
+            null, 
+            ValueDisplayType.DateTimeAsDateOnly);
         AssertChange(
             changedProperties
                 .SingleOrDefault(c => c.Name == nameof(PunchItem.MaterialExternalNo)),

--- a/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryCreatedV1ContractTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryCreatedV1ContractTests.cs
@@ -14,7 +14,6 @@ public class HistoryCreatedV1ContractTests : ContractTestBase<IHistoryItemCreate
         // Arrange
         var expectedProperties = new Dictionary<string, Type>
         {
-            { "Plant", typeof(string) },
             { "DisplayName", typeof(string) },
             { "Guid", typeof(Guid) },
             { "ParentGuid", typeof(Guid?) },

--- a/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryDeletedV1ContractTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryDeletedV1ContractTests.cs
@@ -14,7 +14,6 @@ public class HistoryDeletedV1ContractTests : ContractTestBase<IHistoryItemDelete
         // Arrange
         var expectedProperties = new Dictionary<string, Type>
         {
-            { "Plant", typeof(string) },
             { "DisplayName", typeof(string) },
             { "Guid", typeof(Guid) },
             { "ParentGuid", typeof(Guid?) },

--- a/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryUpdatedV1ContractTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryUpdatedV1ContractTests.cs
@@ -16,6 +16,7 @@ public class HistoryUpdatedV1ContractTests : ContractTestBase<IHistoryItemUpdate
         {
             { "DisplayName", typeof(string) },
             { "Guid", typeof(Guid) },
+            { "ParentGuid", typeof(Guid?) },
             { "EventBy", typeof(User) },
             { "EventAtUtc", typeof(DateTime) },
             { "ChangedProperties", typeof(List<IChangedProperty>) }

--- a/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryUpdatedV1ContractTests.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.MessageContracts.Tests/History/HistoryUpdatedV1ContractTests.cs
@@ -14,7 +14,6 @@ public class HistoryUpdatedV1ContractTests : ContractTestBase<IHistoryItemUpdate
         // Arrange
         var expectedProperties = new Dictionary<string, Type>
         {
-            { "Plant", typeof(string) },
             { "DisplayName", typeof(string) },
             { "Guid", typeof(Guid) },
             { "EventBy", typeof(User) },

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
@@ -219,13 +219,11 @@ public abstract class TestsBase
 
     protected void AssertHistoryCreatedIntegrationEvent(
         HistoryCreatedIntegrationEvent historyEvent, 
-        string plant, 
         string displayName,
         Guid parentGuid,
         IHaveGuid guidEntity,
         ICreationAuditable creationAuditableEntity)
     {
-        Assert.AreEqual(plant, historyEvent.Plant);
         Assert.AreEqual(displayName, historyEvent.DisplayName);
         Assert.AreEqual(guidEntity.Guid, historyEvent.Guid);
         Assert.AreEqual(parentGuid, historyEvent.ParentGuid);
@@ -243,7 +241,6 @@ public abstract class TestsBase
     {
         Assert.IsNotNull(historyEvent);
         Assert.AreEqual(displayName, historyEvent.DisplayName);
-        Assert.AreEqual(plant, historyEvent.Plant);
         Assert.AreEqual(guidEntity.Guid, historyEvent.Guid);
         Assert.AreEqual(modificationAuditableEntity.ModifiedAtUtc, historyEvent.EventAtUtc);
         Assert.AreEqual(modificationAuditableEntity.ModifiedBy!.Guid, historyEvent.EventBy.Oid);
@@ -260,7 +257,6 @@ public abstract class TestsBase
     {
         Assert.IsNotNull(historyEvent);
         Assert.AreEqual(displayName, historyEvent.DisplayName);
-        Assert.AreEqual(plant, historyEvent.Plant);
         Assert.AreEqual(guidEntity.Guid, historyEvent.Guid);
 
         // Our entities don't have DeletedByOid / DeletedAtUtc ...

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
@@ -237,11 +237,13 @@ public abstract class TestsBase
         string plant,
         string displayName,
         IHaveGuid guidEntity,
-        IModificationAuditable modificationAuditableEntity)
+        IModificationAuditable modificationAuditableEntity,
+        Guid? parentGuid = null)
     {
         Assert.IsNotNull(historyEvent);
         Assert.AreEqual(displayName, historyEvent.DisplayName);
         Assert.AreEqual(guidEntity.Guid, historyEvent.Guid);
+        Assert.AreEqual(parentGuid, historyEvent.ParentGuid);
         Assert.AreEqual(modificationAuditableEntity.ModifiedAtUtc, historyEvent.EventAtUtc);
         Assert.AreEqual(modificationAuditableEntity.ModifiedBy!.Guid, historyEvent.EventBy.Oid);
         Assert.AreEqual(modificationAuditableEntity.ModifiedBy!.GetFullName(), historyEvent.EventBy.FullName);

--- a/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.Test.Common/TestsBase.cs
@@ -44,30 +44,47 @@ public abstract class TestsBase
         TimeService.SetProvider(_timeProvider);
     }
 
-    protected void AssertPerson(IProperty property, User value)
+    protected void AssertPerson(
+        IProperty property,
+        User value,
+        ValueDisplayType valueDisplayType = ValueDisplayType.UserAsNameOnly)
     {
         Assert.IsNotNull(property);
         var user = property.Value as User;
         Assert.IsNotNull(user);
         Assert.AreEqual(value.Oid, user.Oid);
         Assert.AreEqual(value.FullName, user.FullName);
+        Assert.AreEqual(valueDisplayType, property.ValueDisplayType);
     }
 
-    protected void AssertProperty(IProperty property, object value)
+    protected void AssertProperty(
+        IProperty property,
+        object value,
+        ValueDisplayType valueDisplayType = ValueDisplayType.StringAsText)
     {
         Assert.IsNotNull(property);
         Assert.IsNotNull(value);
         Assert.AreEqual(value, property.Value);
+        Assert.AreEqual(valueDisplayType, property.ValueDisplayType);
     }
 
-    protected void AssertChange(IChangedProperty change, object oldValue, object newValue)
+    protected void AssertChange(
+        IChangedProperty change,
+        object oldValue,
+        object newValue,
+        ValueDisplayType valueDisplayType = ValueDisplayType.StringAsText)
     {
         Assert.IsNotNull(change);
         Assert.AreEqual(oldValue, change.OldValue);
         Assert.AreEqual(newValue, change.NewValue);
+        Assert.AreEqual(valueDisplayType, change.ValueDisplayType);
     }
 
-    protected void AssertPersonChange(IChangedProperty change, User oldValue, User newValue)
+    protected void AssertPersonChange(
+        IChangedProperty change,
+        User oldValue,
+        User newValue,
+        ValueDisplayType valueDisplayType = ValueDisplayType.UserAsNameOnly)
     {
         Assert.IsNotNull(change);
         if (change.OldValue is null)
@@ -92,6 +109,7 @@ public abstract class TestsBase
             Assert.AreEqual(newValue.Oid, user.Oid);
             Assert.AreEqual(newValue.FullName, user.FullName);
         }
+        Assert.AreEqual(valueDisplayType, change.ValueDisplayType);
     }
 
     protected void AssertRequiredProperties(PunchItem punchItem, IPunchItem integrationEvent)


### PR DESCRIPTION
* Plant should not be a part of the History message. History must be 100% generic
* Updates to History also need ParentGuid (optional)
* For each Property / ChangedProperty in History, we need info about what this is (value type + how to present to end user) .. Solution with enum discussed with TechLead