### PR TITLE
110749 - Set credential on TelemetryConfiguration

### DIFF
--- a/src/Equinor.ProCoSys.Completion.WebApi/Misc/IConfigurationExtension.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Misc/IConfigurationExtension.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Equinor.ProCoSys.Completion.WebApi.Misc;
+
+public static class IConfigurationExtension
+{
+    public static bool IsDevOnLocalhost(this IConfiguration configuration)
+        => configuration.GetValue<bool>("Application:DevOnLocalhost");
+}

--- a/src/Equinor.ProCoSys.Completion.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Azure.Identity;
 using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Completion.WebApi.Misc;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
@@ -35,7 +36,14 @@ public class Program
                         options.Connect(connectionString)
                             .ConfigureKeyVault(kv =>
                             {
-                                kv.SetCredential(new ManagedIdentityCredential());
+                                if (settings.IsDevOnLocalhost())
+                                {
+                                    kv.SetCredential(new DefaultAzureCredential());
+                                }
+                                else
+                                {
+                                    kv.SetCredential(new ManagedIdentityCredential());
+                                }
                             })
                             .Select(KeyFilter.Any)
                             .Select(KeyFilter.Any, context.HostingEnvironment.EnvironmentName)

--- a/src/Equinor.ProCoSys.Completion.WebApi/Startup.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Startup.cs
@@ -30,6 +30,7 @@ using System.IO;
 using Equinor.ProCoSys.Completion.WebApi.HostedServices;
 using Azure.Core;
 using Azure.Identity;
+using Equinor.ProCoSys.Completion.WebApi.Misc;
 using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Equinor.ProCoSys.Completion.WebApi;
@@ -50,7 +51,7 @@ public class Startup
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
     {
-        var devOnLocalhost = Configuration.GetValue<bool>("Application:DevOnLocalhost");
+        var devOnLocalhost = Configuration.IsDevOnLocalhost();
 
         if (devOnLocalhost && Configuration.GetValue<bool>("MigrateDatabase"))
         {


### PR DESCRIPTION
[AB#110749](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/110749)

The main reason for this PR, is to use Managed Identity when logging to Appl Insight
Other changes in startup.cs regarding checking the setting Application:DevOnLocalhost, is to better distinguish between running at localhost vs our Development environment in Azure (The Application:DevOnLocalhost was introduced in https://github.com/equinor/procosys-completion-api/pull/108)