### PR TITLE
254 - Fix attachment permissions

### DIFF
--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
@@ -419,7 +419,7 @@ public class PunchItemsController : ControllerBase
     /// <param name="dto"></param>
     /// <returns>Guid and RowVersion of created link</returns>
     /// <response code="400">Input validation error (error returned in body)</response>
-    [AuthorizeAny(Permissions.PUNCHITEM_ATTACH, Permissions.APPLICATION_TESTER)]
+    [AuthorizeAny(Permissions.PUNCHITEM_WRITE, Permissions.APPLICATION_TESTER)]
     [HttpPost("{guid}/Links")]
     public async Task<ActionResult<GuidAndRowVersion>> CreatePunchItemLink(
         [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -577,7 +577,7 @@ public class PunchItemsController : ControllerBase
     /// <returns>Guid and RowVersion of created attachment/picture</returns>
     /// <response code="400">Input validation error (error returned in body)</response>
     /// <remarks>Will give validation error if uploading same attachment with same filename as an existing attachment. Use PUT endpoint if overwrite is intended</remarks>
-    [AuthorizeAny(Permissions.PUNCHITEM_ATTACH, Permissions.APPLICATION_TESTER)]
+    [AuthorizeAny(Permissions.PUNCHITEM_WRITE, Permissions.APPLICATION_TESTER)]
     [HttpPost("{guid}/Attachments")]
     public async Task<ActionResult<GuidAndRowVersion>> UploadPunchItemAttachment(
         [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -609,7 +609,7 @@ public class PunchItemsController : ControllerBase
     /// <returns>New RowVersion of attachment/picture</returns>
     /// <response code="400">Input validation error (error returned in body)</response>
     /// <remarks>Will give validation error if attachment with same filename don't exist. Use POST endpoint if uploading new attachment is intended</remarks>
-    [AuthorizeAny(Permissions.PUNCHITEM_ATTACH, Permissions.APPLICATION_TESTER)]
+    [AuthorizeAny(Permissions.PUNCHITEM_WRITE, Permissions.APPLICATION_TESTER)]
     [HttpPut("{guid}/Attachments")]
     public async Task<ActionResult<string>> OverwriteExistingPunchItemAttachment(
         [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -715,7 +715,7 @@ public class PunchItemsController : ControllerBase
     /// <param name="guid">Guid on PunchItem</param>
     /// <param name="attachmentGuid">Guid on attachment/picture</param>
     /// <param name="dto"></param>
-    [AuthorizeAny(Permissions.PUNCHITEM_DETACH, Permissions.APPLICATION_TESTER)]
+    [AuthorizeAny(Permissions.PUNCHITEM_WRITE, Permissions.APPLICATION_TESTER)]
     [HttpDelete("{guid}/Attachments/{attachmentGuid}")]
     public async Task<ActionResult> DeleteAttachment(
         [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -776,7 +776,7 @@ public class PunchItemsController : ControllerBase
     /// <param name="dto"></param>
     /// <returns>New RowVersion of attachment/picture</returns>
     /// <response code="404">PunchItem or attachment/picture not found</response>
-    [AuthorizeAny(Permissions.PUNCHITEM_ATTACH, Permissions.APPLICATION_TESTER)]
+    [AuthorizeAny(Permissions.PUNCHITEM_WRITE, Permissions.APPLICATION_TESTER)]
     [HttpPut("{guid}/Attachments/{attachmentGuid}")]
     public async Task<ActionResult<string>> UpdatePunchItemAttachment(
         [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]

--- a/src/Equinor.ProCoSys.Completion.WebApi/Permissions.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Permissions.cs
@@ -11,8 +11,6 @@ public class Permissions
     public const string PUNCHITEM_CREATE = "PUNCHLISTITEM/CREATE";
     public const string PUNCHITEM_DELETE = "PUNCHLISTITEM/DELETE";
     public const string PUNCHITEM_WRITE = "PUNCHLISTITEM/WRITE";
-    public const string PUNCHITEM_ATTACH = "PUNCHLISTITEM/ATTACH";
-    public const string PUNCHITEM_DETACH = "PUNCHLISTITEM/DETACH";
     public const string PUNCHITEM_CLEAR = "PUNCHLISTITEM/CLEAR";
     public const string PUNCHITEM_VERIFY = "PUNCHLISTITEM/VERIFY";
     public const string USER_READ = "USER/READ";

--- a/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.Completion.WebApi.IntegrationTests/TestFactory.cs
@@ -512,8 +512,6 @@ public Dictionary<string, KnownTestData> SeededData { get; }
                     Permissions.PUNCHITEM_CLEAR,
                     Permissions.PUNCHITEM_VERIFY,
                     Permissions.PUNCHITEM_WRITE,
-                    Permissions.PUNCHITEM_ATTACH,
-                    Permissions.PUNCHITEM_DETACH,
                     Permissions.PUNCHITEM_DELETE,
                     Permissions.PUNCHITEM_READ,
                     Permissions.LIBRARY_READ,
@@ -547,8 +545,6 @@ public Dictionary<string, KnownTestData> SeededData { get; }
                     Permissions.PUNCHITEM_CLEAR,
                     Permissions.PUNCHITEM_VERIFY,
                     Permissions.PUNCHITEM_WRITE,
-                    Permissions.PUNCHITEM_ATTACH,
-                    Permissions.PUNCHITEM_DETACH,
                     Permissions.PUNCHITEM_DELETE,
                     Permissions.PUNCHITEM_READ,
                     Permissions.LIBRARY_READ


### PR DESCRIPTION
Removed permissions "PUNCHLISTITEM/ATTACH" / "PUNCHLISTITEM/DETACH". Use "PUNCHLISTITEM/WRITE"

https://github.com/equinor/cc-toolbox/issues/254