### PR TITLE
478 - Lack of input validation

### DIFF
--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PatchOperationInputValidator.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PatchOperationInputValidator.cs
@@ -65,14 +65,14 @@ public class PatchOperationInputValidator : IPatchOperationInputValidator
 
     public bool HaveValidLengthOfStrings<T>(List<Operation<T>> operations) where T : class
     {
-        var illegalOperations = GetInvalidStringOperations(typeof(T).Name, operations);
+        var illegalOperations = GetInvalidStringOperations(operations);
 
         return illegalOperations.Count == 0;
     }
 
     public string? GetMessageForInvalidLengthOfStrings<T>(List<Operation<T>> operations) where T : class
     {
-        var illegalOperations = GetInvalidStringOperations(typeof(T).Name, operations);
+        var illegalOperations = GetInvalidStringOperations(operations);
         if (illegalOperations.Count == 0)
         {
             return null;
@@ -110,12 +110,12 @@ public class PatchOperationInputValidator : IPatchOperationInputValidator
                 if (operation.Value is null)
                 {
                     illegalOperations.Add(
-                        $"Can't assign null-value to property {operation.Key} of type {propType} in {typeName}");
+                        $"Can't assign null-value to property {operation.Key} of type {propType}");
                 }
                 else
                 {
                     illegalOperations.Add(
-                        $"Can't assign value value of type {operation.Value.GetType()} to property {operation.Key} of type {propType} in {typeName}");
+                        $"Can't assign value value of type {operation.Value.GetType()} to property {operation.Key} of type {propType}");
                 }
             }
         }
@@ -215,7 +215,7 @@ public class PatchOperationInputValidator : IPatchOperationInputValidator
         return requiredProperties.Intersect(replaceOperationsToSetNull).ToList();
     }
 
-    private List<string> GetInvalidStringOperations<T>(string typeName, List<Operation<T>> operations) where T : class
+    private List<string> GetInvalidStringOperations<T>(List<Operation<T>> operations) where T : class
     {
         var illegalOperations = new List<string>();
         var type = typeof(T);
@@ -241,7 +241,7 @@ public class PatchOperationInputValidator : IPatchOperationInputValidator
             var stringLengthAttribute = propertyWithLengthLimiting.GetCustomAttribute<StringLengthAttribute>(false)!;
             if (!stringLengthAttribute.IsValid(operation.value as string, out var message))
             {
-                illegalOperations.Add($"Can't assign value to property {propName} in {typeName}. {message}");
+                illegalOperations.Add($"Can't assign value to property {propName}. {message}");
             }
         }
 

--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Auth;
@@ -36,7 +35,6 @@ using Equinor.ProCoSys.Completion.WebApi.Middleware;
 using Equinor.ProCoSys.Completion.WebApi.Swagger;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace Equinor.ProCoSys.Completion.WebApi.Controllers.PunchItems;
@@ -46,7 +44,7 @@ namespace Equinor.ProCoSys.Completion.WebApi.Controllers.PunchItems;
 /// </summary>
 [ApiController]
 [Route("PunchItems")]
-public class PunchItemsController(IMediator mediator, ILogger<PunchItemsController> logger) : ControllerBase
+public class PunchItemsController(IMediator mediator) : ControllerBase
 {
     #region PunchItems
 
@@ -482,61 +480,8 @@ public class PunchItemsController(IMediator mediator, ILogger<PunchItemsControll
         CancellationToken cancellationToken,
         [FromRoute] Guid guid)
     {
-        //var ipAddress = GetClientIpAddress();
-
         var result = await mediator.Send(new GetPunchItemAttachmentsQuery(guid, null, null), cancellationToken);
         return Ok(result);
-    }
-
-    private string? GetIpAddressFromHeaders()
-    {
-        var proCoSysForwardHeader = Request.Headers["X-Forwarded-For-ProCoSys"].FirstOrDefault();
-        if (!string.IsNullOrEmpty(proCoSysForwardHeader))
-        {
-            return proCoSysForwardHeader;
-        }
-
-        var forwardedForHeader = Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrEmpty(forwardedForHeader))
-        {
-            return forwardedForHeader;
-        }
-
-        var realIpHeader = Request.Headers["X-Real-IP"].FirstOrDefault();
-        if (!string.IsNullOrEmpty(realIpHeader))
-        {
-            return realIpHeader;
-        }
-
-        logger.LogInformation("No headers found, using connection: {IpAddress}",
-            Request.HttpContext.Connection.RemoteIpAddress?.ToString());
-        return Request.HttpContext.Connection.RemoteIpAddress?.ToString();
-    }
-    
-    private string? GetClientIpAddress()
-    {
-        var ipAddress = GetIpAddressFromHeaders();
-        
-        if (string.IsNullOrEmpty(ipAddress))
-        {
-            logger.LogWarning("No IP address found");
-            return null;
-        }
-        
-        if (ipAddress.Contains(','))
-        {
-            var ipAddresses = ipAddress.Split(",");
-            ipAddress = ipAddresses[0].Trim();
-        }
-
-        if (ipAddress.Contains(':'))
-        {
-            var ipAddresses = ipAddress.Split(":");
-            ipAddress = ipAddresses[0].Trim();
-        }
-        
-        logger.LogInformation("Using address: {IpAddress}", ipAddress);
-        return ipAddress;
     }
 
     /// <summary>

--- a/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Controllers/PunchItems/PunchItemsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Auth;
@@ -35,6 +36,7 @@ using Equinor.ProCoSys.Completion.WebApi.Middleware;
 using Equinor.ProCoSys.Completion.WebApi.Swagger;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace Equinor.ProCoSys.Completion.WebApi.Controllers.PunchItems;
@@ -44,7 +46,7 @@ namespace Equinor.ProCoSys.Completion.WebApi.Controllers.PunchItems;
 /// </summary>
 [ApiController]
 [Route("PunchItems")]
-public class PunchItemsController(IMediator mediator) : ControllerBase
+public class PunchItemsController(IMediator mediator, ILogger<PunchItemsController> logger) : ControllerBase
 {
     #region PunchItems
 
@@ -480,8 +482,61 @@ public class PunchItemsController(IMediator mediator) : ControllerBase
         CancellationToken cancellationToken,
         [FromRoute] Guid guid)
     {
+        //var ipAddress = GetClientIpAddress();
+
         var result = await mediator.Send(new GetPunchItemAttachmentsQuery(guid, null, null), cancellationToken);
         return Ok(result);
+    }
+
+    private string? GetIpAddressFromHeaders()
+    {
+        var proCoSysForwardHeader = Request.Headers["X-Forwarded-For-ProCoSys"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(proCoSysForwardHeader))
+        {
+            return proCoSysForwardHeader;
+        }
+
+        var forwardedForHeader = Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(forwardedForHeader))
+        {
+            return forwardedForHeader;
+        }
+
+        var realIpHeader = Request.Headers["X-Real-IP"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(realIpHeader))
+        {
+            return realIpHeader;
+        }
+
+        logger.LogInformation("No headers found, using connection: {IpAddress}",
+            Request.HttpContext.Connection.RemoteIpAddress?.ToString());
+        return Request.HttpContext.Connection.RemoteIpAddress?.ToString();
+    }
+    
+    private string? GetClientIpAddress()
+    {
+        var ipAddress = GetIpAddressFromHeaders();
+        
+        if (string.IsNullOrEmpty(ipAddress))
+        {
+            logger.LogWarning("No IP address found");
+            return null;
+        }
+        
+        if (ipAddress.Contains(','))
+        {
+            var ipAddresses = ipAddress.Split(",");
+            ipAddress = ipAddresses[0].Trim();
+        }
+
+        if (ipAddress.Contains(':'))
+        {
+            var ipAddresses = ipAddress.Split(":");
+            ipAddress = ipAddresses[0].Trim();
+        }
+        
+        logger.LogInformation("Using address: {IpAddress}", ipAddress);
+        return ipAddress;
     }
 
     /// <summary>

--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ValidatorsConfig.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ValidatorsConfig.cs
@@ -20,6 +20,7 @@ public static class ValidatorsConfig
         {
             typeof(IQueryMarker).GetTypeInfo().Assembly,
             typeof(ICommandMarker).GetTypeInfo().Assembly,
+            typeof(Program).GetTypeInfo().Assembly
         });
         return builder;
     }

--- a/src/Equinor.ProCoSys.Completion.WebApi/Properties/launchSettings.json
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Equinor.ProCoSys.Completion.WebApi": {
       "commandName": "Project",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
https://github.com/equinor/cc-toolbox/issues/478

Input validation was made, and well tested through unit tests.. However, the initialization was forgotten. See https://github.com/equinor/procosys-completion-api/pull/256/commits/54a6c992aa75a50ac44588b546e662c2a20a6392

Integration tests made to proof it