### PR TITLE
504 - Servicebus - replace connection string with managed identity

### DIFF
--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/ApplicationModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Core;
 using Equinor.ProCoSys.Auth.Authentication;
 using Equinor.ProCoSys.Auth.Authorization;
 using Equinor.ProCoSys.Auth.Caches;
@@ -52,7 +53,7 @@ namespace Equinor.ProCoSys.Completion.WebApi.DIModules;
 
 public static class ApplicationModule
 {
-    public static void AddApplicationModules(this IServiceCollection services, IConfiguration configuration)
+    public static void AddApplicationModules(this IServiceCollection services, IConfiguration configuration, TokenCredential credential)
     {
         services.Configure<ApplicationOptions>(configuration.GetSection("Application"));
         services.Configure<MainApiOptions>(configuration.GetSection("MainApi"));
@@ -75,7 +76,7 @@ public static class ApplicationModule
             configure.AddApplicationInsights();
         });
 
-        services.AddMassTransitModule(configuration);
+        services.AddMassTransitModule(configuration, credential);
 
         services.AddHttpContextAccessor();
         services.AddHttpClient();

--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 using Azure.Identity;
 using Equinor.ProCoSys.Completion.Command.MessageProducers;
 using Equinor.ProCoSys.Completion.Infrastructure;
@@ -123,9 +124,15 @@ public static class MassTransitModule
             x.UsingAzureServiceBus((context, cfg) =>
             {
                 var serviceBusNamespace = configuration.GetValue<string>("ServiceBusNamespace");
+                if (string.IsNullOrEmpty(serviceBusNamespace))
+                {
+                    throw new Exception("ServiceBusNamespace is not set in appsettings.json");
+                }
+                var serviceUri = new Uri(serviceBusNamespace);
+
                 var credential = new DefaultAzureCredential();
 
-                cfg.Host(serviceBusNamespace, host =>
+                cfg.Host(serviceUri, host =>
                 {
                     host.TokenCredential = credential;
                 });

--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using Azure.Core;
 using Azure.Identity;
 using Equinor.ProCoSys.Completion.Command.MessageProducers;
 using Equinor.ProCoSys.Completion.Infrastructure;
@@ -14,7 +15,7 @@ namespace Equinor.ProCoSys.Completion.WebApi.DIModules;
 
 public static class MassTransitModule
 {
-    public static void AddMassTransitModule(this IServiceCollection services, IConfiguration configuration)
+    public static void AddMassTransitModule(this IServiceCollection services, IConfiguration configuration, TokenCredential credential)
     {
         services.AddMassTransit(x =>
         {
@@ -126,11 +127,9 @@ public static class MassTransitModule
                 var serviceBusNamespace = configuration.GetValue<string>("ServiceBusNamespace");
                 if (string.IsNullOrEmpty(serviceBusNamespace))
                 {
-                    throw new Exception("ServiceBusNamespace is not set in appsettings.json");
+                    throw new Exception("ServiceBusNamespace is not properly configured");
                 }
                 var serviceUri = new Uri(serviceBusNamespace);
-
-                var credential = new DefaultAzureCredential();
 
                 cfg.Host(serviceUri, host =>
                 {

--- a/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/DiModules/MassTransitModule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Azure.Identity;
 using Equinor.ProCoSys.Completion.Command.MessageProducers;
 using Equinor.ProCoSys.Completion.Infrastructure;
 using Equinor.ProCoSys.Completion.WebApi.MassTransit;
@@ -121,9 +122,14 @@ public static class MassTransitModule
 
             x.UsingAzureServiceBus((context, cfg) =>
             {
-                var connectionString = configuration.GetConnectionString("ServiceBus");
+                var serviceBusNamespace = configuration.GetValue<string>("ServiceBusNamespace");
+                var credential = new DefaultAzureCredential();
 
-                cfg.Host(connectionString);
+                cfg.Host(serviceBusNamespace, host =>
+                {
+                    host.TokenCredential = credential;
+                });
+
 
                 cfg.MessageTopology.SetEntityNameFormatter(new ProCoSysKebabCaseEntityNameFormatter());
                 

--- a/src/Equinor.ProCoSys.Completion.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Program.cs
@@ -73,7 +73,7 @@ builder.ConfigureValidators();
 builder.ConfigureTelemetry(credential, devOnLocalhost);
 
 builder.Services.AddMediatrModules();
-builder.Services.AddApplicationModules(builder.Configuration);
+builder.Services.AddApplicationModules(builder.Configuration, credential);
 
 if (builder.Configuration.GetValue<bool>("TieImport:Enable"))
 {

--- a/src/Equinor.ProCoSys.Completion.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.Completion.WebApi/appsettings.json
@@ -54,7 +54,6 @@
   },
   "ConnectionStrings": {
     "CompletionContext": "",
-    "ServiceBus": "",
     "AppConfig": "",
     "RedisCache": ""
   },
@@ -92,6 +91,7 @@
   },
   "MigrateDatabase": false,
   "SeedDummyData": false,
+  "ServiceBusNamespace": "",
   "SyncToPCS4Options": {
     "Endpoint": "https://localhost:44352/",
     "Enabled": false,


### PR DESCRIPTION
Moved from using Connection string for ServiceBus to using Managed Identity

https://github.com/equinor/cc-toolbox/issues/529