### PR TITLE
Adding responsible disclosure instructions as per compliance policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,16 @@
-If you discover a security vulnerability in this project, please follow the steps below to report it.
+If you discover a security vulnerability in this project, please follow these steps to responsibly disclose it:
 
-### For "non-critical" issues
+1. **Do not** create a public GitHub issue for the vulnerability.
+2. Follow our guideline for Responsible Disclosure Policy at [https://www.equinor.com/about-us/csirt](https://www.equinor.com/about-us/csirt) to report the issue
 
-- **Alternative A:**  
-Create a GitHub issue for the vulnerability. Avoid putting sensitive information in the issue.
+The following information will help us triage your report more quickly:
 
-- **Alternative B:**  
-Send an email to the projects maintainer at [sks@equinor.com](mailto:sks@equinor.com) describing the issue.
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
 
-### For "critical" and time sensitive issues
-
-Phone the Equinor helpdesk:
-
-- Norway (+47) 51 999 222
-- US/Canada (+1) 713 878 6970
+We prefer all communications to be in English.


### PR DESCRIPTION
As per compliance policy for public repo: https://github.com/equinor/it-professional-network/blob/master/doc/SECURITY-template.md

Note: Adjusting content to reflect instructions based on public vs internal/private repos.