### PR TITLE
1608 auth version update

### DIFF
--- a/src/Equinor.ProCoSys.Completion.Command/Equinor.ProCoSys.Completion.Command.csproj
+++ b/src/Equinor.ProCoSys.Completion.Command/Equinor.ProCoSys.Completion.Command.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="4.0.0" />
     <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="2.1.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MassTransit" Version="8.2.5" />

--- a/src/Equinor.ProCoSys.Completion.Command/Equinor.ProCoSys.Completion.Command.csproj
+++ b/src/Equinor.ProCoSys.Completion.Command/Equinor.ProCoSys.Completion.Command.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
     <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="2.1.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MassTransit" Version="8.2.5" />

--- a/src/Equinor.ProCoSys.Completion.DbSyncToPCS4/Equinor.ProCoSys.Completion.DbSyncToPCS4.csproj
+++ b/src/Equinor.ProCoSys.Completion.DbSyncToPCS4/Equinor.ProCoSys.Completion.DbSyncToPCS4.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/src/Equinor.ProCoSys.Completion.DbSyncToPCS4/Equinor.ProCoSys.Completion.DbSyncToPCS4.csproj
+++ b/src/Equinor.ProCoSys.Completion.DbSyncToPCS4/Equinor.ProCoSys.Completion.DbSyncToPCS4.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/src/Equinor.ProCoSys.Completion.Domain/Equinor.ProCoSys.Completion.Domain.csproj
+++ b/src/Equinor.ProCoSys.Completion.Domain/Equinor.ProCoSys.Completion.Domain.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Common" Version="3.0.0" />
+    <PackageReference Include="Equinor.ProCoSys.Common" Version="3.0.1" />
     <PackageReference Include="MassTransit.Abstractions" Version="8.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/Equinor.ProCoSys.Completion.ForeignApi/Equinor.ProCoSys.Completion.ForeignApi.csproj
+++ b/src/Equinor.ProCoSys.Completion.ForeignApi/Equinor.ProCoSys.Completion.ForeignApi.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
     <PackageReference Include="Microsoft.Identity.Web.TokenAcquisition" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Equinor.ProCoSys.Completion.ForeignApi/Equinor.ProCoSys.Completion.ForeignApi.csproj
+++ b/src/Equinor.ProCoSys.Completion.ForeignApi/Equinor.ProCoSys.Completion.ForeignApi.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="4.0.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenAcquisition" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Equinor.ProCoSys.Completion.Infrastructure.csproj
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Equinor.ProCoSys.Completion.Infrastructure.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />

--- a/src/Equinor.ProCoSys.Completion.Infrastructure/Equinor.ProCoSys.Completion.Infrastructure.csproj
+++ b/src/Equinor.ProCoSys.Completion.Infrastructure/Equinor.ProCoSys.Completion.Infrastructure.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="4.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />

--- a/src/Equinor.ProCoSys.Completion.WebApi/Equinor.ProCoSys.Completion.WebApi.csproj
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Equinor.ProCoSys.Completion.WebApi.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.2.1" />
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
     <PackageReference Include="Equinor.ProCoSys.PcsServiceBus" Version="4.3.25" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />

--- a/src/Equinor.ProCoSys.Completion.WebApi/Equinor.ProCoSys.Completion.WebApi.csproj
+++ b/src/Equinor.ProCoSys.Completion.WebApi/Equinor.ProCoSys.Completion.WebApi.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.2.1" />
-    <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.5" />
+    <PackageReference Include="Equinor.ProCoSys.Auth" Version="4.0.0" />
     <PackageReference Include="Equinor.ProCoSys.PcsServiceBus" Version="4.3.25" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />


### PR DESCRIPTION
Fixing an issue where the DbSyncToPCS project was using a Common package that did not support identity authentication.

https://github.com/equinor/cc-toolbox/issues/1608